### PR TITLE
fix "Argument list too long" for tar command

### DIFF
--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -390,12 +390,30 @@ class SSHContext (object):
 
     def _get_files(self, 
                    files) :
-        of = self.job_uuid + '.tgz'
-        flist = ""
-        for ii in files :
-            flist += " " + ii
+        of = self.job_uuid + '.tar.gz'
         # remote tar
-        self.block_checkcall('tar czf %s %s' % (of, flist))
+        # If the number of files are large, we may get "Argument list too long" error.
+        # Thus, we may run tar commands for serveral times and tar only 100 files for
+        # each time.
+        per_nfile = 100
+        ntar = len(files) // per_nfile + 1
+        if ntar <= 1:
+            self.block_checkcall('tar czf %s %s' % (of, " ".join(files)))
+        else:
+            of_tar = self.job_uuid + '.tar'
+            for ii in range(ntar):
+                ff = files[per_nfile * ii : per_nfile * (ii+1)]
+                if ii == 0:
+                    # tar cf for the first time
+                    self.block_checkcall('tar cf %s %s' % (of_tar, " ".join(ff)))
+                else:
+                    # append using tar rf
+                    # -r, --append append files to the end of an archive
+                    self.block_checkcall('tar rf %s %s' % (of_tar, " ".join(ff)))
+            # compress the tar file using gzip, and will get a tar.gz file
+            # overwrite considering dpgen may stop and restart
+            # -f, --force force overwrite of output file and compress links
+            self.block_checkcall('gzip -f %s' % of_tar)
         # trans
         from_f = os.path.join(self.remote_root, of)
         to_f = os.path.join(self.local_root, of)


### PR DESCRIPTION
If the number of files is too much, it will raise an error
"Argument list too long". A solution is to split it to several
commands.
> RuntimeError: Get error code 1 in calling tar czf ... through ssh with job: 57c454d1-1ca2-4b6b-a5c4-8c468898586e . message: /bin/bash: Argument list too long

Also gzip with force overwrite
This will fix the bug "gzip: 570aef2d-1f5f-4de3-b767-d5a2c4a8e41a.tar.gz already exists; not overwritten" if dpgen stop and restart.

impletment deepmodeling/dpgen#380 and deepmodeling/dpgen#384
