### PR TITLE
fix ResourceWarning in issue #47 (#issue41 comment 8)

### DIFF
--- a/dpdispatcher/shell.py
+++ b/dpdispatcher/shell.py
@@ -1,5 +1,4 @@
 import os,sys,time,random,uuid
-from typing_extensions import runtime
 import psutil
 
 from dpdispatcher.JobStatus import JobStatus

--- a/dpdispatcher/shell.py
+++ b/dpdispatcher/shell.py
@@ -1,4 +1,5 @@
 import os,sys,time,random,uuid
+from typing_extensions import runtime
 import psutil
 
 from dpdispatcher.JobStatus import JobStatus
@@ -23,10 +24,10 @@ class Shell(Machine):
         script_file_name = job.script_file_name
         job_id_name = job.job_hash + '_job_id'
         self.context.write_file(fname=script_file_name, write_str=script_str)
-        proc = self.context.call('cd %s && exec bash %s' % (self.context.remote_root, script_file_name))
-
+        proc = self.context.call('cd %s && exec bash %s &' % (self.context.remote_root, script_file_name) )
+        proc.wait()
+        # proc.kill()
         job_id = int(proc.pid)
-        # print('shell.do_submit.job_id', job_id)
         self.context.write_file(job_id_name, str(job_id))
         return job_id
 

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -516,7 +516,7 @@ class Job(object):
             raise RuntimeError("job_state for job {job} is unknown".format(job=self))
 
         if job_state == JobStatus.terminated:
-            dlog.info(f"job: {self.job_hash} terminated; restarting job")
+            dlog.info(f"job: {self.job_hash} {self.job_id} terminated; restarting job")
             if self.fail_count > 3:
                 raise RuntimeError("job:job {job} failed 3 times".format(job=self))
             self.fail_count += 1


### PR DESCRIPTION
And now it will have the warning like 

> sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=7>

And another warning 
> /some/path/to/dpdispatcher/submission.py:568: ResourceWarning: unclosed file <_io.BufferedReader name=6>

is due to taht when we 'submit' a job  in local shell, we will create a subprocess and initialize a shell to run theses commands.  So the process still exist after we 'submit'  the job to a shell which is just what we expect.