### PR TITLE
dpdispatcher will try to save the submission state when meet exceptio…

### DIFF
--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -215,8 +215,12 @@ class Submission(object):
         If the job state is terminated (killed unexpectly), resubmit the job.
         If the job state is unknown, raise an error.
         """
-        for job in self.belonging_jobs:
-            job.handle_unexpected_job_state()
+        try:
+            for job in self.belonging_jobs:
+                job.handle_unexpected_job_state()
+        except Exception as e:
+            self.submission_to_json()
+            raise e
 
     # not used here, submitting job is in handle_unexpected_submission_state.
 


### PR DESCRIPTION
dpdispatcher will try to save the submission state when meet exception in handle_unexpected_submission_state

when meet some errors in submitting jobs, dpdispatcher will try to record the submiited job information
#41 comment11