### PR TITLE
Fix `path` format between Windows and POSIX, also ssh call() return.

### DIFF
--- a/dpdispatcher/shell.py
+++ b/dpdispatcher/shell.py
@@ -29,9 +29,7 @@ class Shell(Machine):
             self.context.write_file(job_id_name, str(job_id))
             return job_id
         else:
-            job_id = int(proc["stdout"].readline())
-            self.context.write_file(job_id_name, str(job_id))
-            return job_id
+            return "#N/A#"
         # proc.kill()
 
 

--- a/dpdispatcher/shell.py
+++ b/dpdispatcher/shell.py
@@ -29,7 +29,9 @@ class Shell(Machine):
             self.context.write_file(job_id_name, str(job_id))
             return job_id
         else:
-            return "#N/A#"
+            job_id = int(proc["stdout"].readline())
+            self.context.write_file(job_id_name, str(job_id))
+            return job_id
         # proc.kill()
 
 

--- a/dpdispatcher/shell.py
+++ b/dpdispatcher/shell.py
@@ -23,15 +23,11 @@ class Shell(Machine):
         job_id_name = job.job_hash + '_job_id'
         self.context.write_file(fname=script_file_name, write_str=script_str)
         proc = self.context.call('cd %s && exec bash %s &' % (self.context.remote_root, script_file_name) )
-        if not isinstance(proc,dict):
-            proc.wait()
-            job_id = int(proc.pid)
-            self.context.write_file(job_id_name, str(job_id))
-            return job_id
-        else:
-            return "#N/A#"
+        proc.wait()
         # proc.kill()
-
+        job_id = int(proc.pid)
+        self.context.write_file(job_id_name, str(job_id))
+        return job_id
 
         # script_file_name = job.script_file_name
         # script_str = self.gen_script(job)

--- a/dpdispatcher/shell.py
+++ b/dpdispatcher/shell.py
@@ -23,11 +23,15 @@ class Shell(Machine):
         job_id_name = job.job_hash + '_job_id'
         self.context.write_file(fname=script_file_name, write_str=script_str)
         proc = self.context.call('cd %s && exec bash %s &' % (self.context.remote_root, script_file_name) )
-        proc.wait()
+        if not isinstance(proc,dict):
+            proc.wait()
+            job_id = int(proc.pid)
+            self.context.write_file(job_id_name, str(job_id))
+            return job_id
+        else:
+            return "#N/A#"
         # proc.kill()
-        job_id = int(proc.pid)
-        self.context.write_file(job_id_name, str(job_id))
-        return job_id
+
 
         # script_file_name = job.script_file_name
         # script_str = self.gen_script(job)

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -379,8 +379,8 @@ class SSHContext(BaseContext):
         return ret        
         
     def call(self, cmd):
-        # stdin, stdout, stderr = self.ssh_session.exec_command(cmd)
-        stdin, stdout, stderr = self.ssh.exec_command('echo $$; ' + cmd)
+        stdin, stdout, stderr = self.ssh_session.exec_command(cmd)
+        # stdin, stdout, stderr = self.ssh.exec_command('echo $$; exec ' + cmd)
         # pid = stdout.readline().strip()
         # print(pid)
         return {'stdin':stdin, 'stdout':stdout, 'stderr':stderr}

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -369,8 +369,8 @@ class SSHContext(BaseContext):
         return ret        
         
     def call(self, cmd):
-        stdin, stdout, stderr = self.ssh_session.exec_command(cmd)
-        # stdin, stdout, stderr = self.ssh.exec_command('echo $$; exec ' + cmd)
+        # stdin, stdout, stderr = self.ssh_session.exec_command(cmd)
+        stdin, stdout, stderr = self.ssh.exec_command('echo $$; ' + cmd)
         # pid = stdout.readline().strip()
         # print(pid)
         return {'stdin':stdin, 'stdout':stdout, 'stderr':stderr}

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -7,7 +7,6 @@ from glob import glob
 from dpdispatcher import dlog
 from dargs.dargs import Argument
 import pathlib
-import subprocess as sp
 # from dpdispatcher.submission import Machine
 
 class SSHSession (object):

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -6,6 +6,8 @@ import os, paramiko, tarfile, time
 from glob import glob
 from dpdispatcher import dlog
 from dargs.dargs import Argument
+import pathlib
+import subprocess as sp
 # from dpdispatcher.submission import Machine
 
 class SSHSession (object):
@@ -240,9 +242,9 @@ class SSHContext(BaseContext):
 
     def bind_submission(self, submission):
         self.submission = submission
-        self.local_root = os.path.join(self.temp_local_root, submission.work_base)
+        self.local_root = pathlib.PurePath(os.path.join(self.temp_local_root, submission.work_base)).as_posix()
         # self.remote_root = os.path.join(self.temp_remote_root, self.submission.submission_hash, self.submission.work_base )
-        self.remote_root = os.path.join(self.temp_remote_root, self.submission.submission_hash)
+        self.remote_root = pathlib.PurePath(os.path.join(self.temp_remote_root, self.submission.submission_hash)).as_posix()
 
         # self.job_uuid = submission.submission_hash
         # dlog.debug("debug:SSHContext.bind_submission"
@@ -348,19 +350,19 @@ class SSHContext(BaseContext):
 
     def write_file(self, fname, write_str):
         self.ssh_session.ensure_alive()
-        with self.sftp.open(os.path.join(self.remote_root, fname), 'w') as fp :
+        with self.sftp.open(pathlib.PurePath(os.path.join(self.remote_root, fname)).as_posix(), 'w') as fp :
             fp.write(write_str)
 
     def read_file(self, fname):
         self.ssh_session.ensure_alive()
-        with self.sftp.open(os.path.join(self.remote_root, fname), 'r') as fp:
+        with self.sftp.open(pathlib.PurePath(os.path.join(self.remote_root, fname)).as_posix(), 'r') as fp:
             ret = fp.read().decode('utf-8')
         return ret
 
     def check_file_exists(self, fname):
         self.ssh_session.ensure_alive()
         try:
-            self.sftp.stat(os.path.join(self.remote_root, fname)) 
+            self.sftp.stat(pathlib.PurePath(os.path.join(self.remote_root, fname)).as_posix())
             ret = True
         except IOError:
             ret = False
@@ -441,8 +443,8 @@ class SSHContext(BaseContext):
         except OSError: 
             pass
         # trans
-        from_f = os.path.join(self.local_root, of)
-        to_f = os.path.join(self.remote_root, of)
+        from_f = pathlib.PurePath(os.path.join(self.local_root, of)).as_posix()
+        to_f = pathlib.PurePath(os.path.join(self.remote_root, of)).as_posix()
         try:
            self.sftp.put(from_f, to_f)
         except FileNotFoundError:
@@ -480,8 +482,8 @@ class SSHContext(BaseContext):
             # -f, --force force overwrite of output file and compress links
             self.block_checkcall('gzip -f %s' % of_tar)
         # trans
-        from_f = os.path.join(self.remote_root, of)
-        to_f = os.path.join(self.local_root, of)
+        from_f = pathlib.PurePath(os.path.join(self.remote_root, of)).as_posix()
+        to_f = pathlib.PurePath(os.path.join(self.local_root, of)).as_posix()
         if os.path.isfile(to_f) :
             os.remove(to_f)
         self.sftp.get(from_f, to_f)


### PR DESCRIPTION
This PR fix two problem.
**The first** is #78, here using `pathlib` to deal with path format different between Win and POSIX. Changed file `ssh_context.py`.
**The second** is a call() issue when directly using shell. Hope it will return correct pid. Changed file `ssh_context.py` and `shell.py`.
**NOTE:** I'm not sure whether changes of `call()` in `ssh_context.py` will influence other functions.
So far, tests on slurm and shell are without any new problem.
