### PR TITLE
prevent logging from being send to the upper logger

### DIFF
--- a/dpdispatcher/__init__.py
+++ b/dpdispatcher/__init__.py
@@ -4,6 +4,7 @@ import os, sys
 
 ROOT_PATH=__path__[0]
 dlog = logging.getLogger(__name__)
+dlog.propagate = False
 dlog.setLevel(logging.INFO)
 dlogf = logging.FileHandler(os.getcwd()+os.sep+'dpdispatcher'+'.log')
 # dlogf = logging.FileHandler('./'+os.sep+SHORT_CMD+'.log')


### PR DESCRIPTION
see https://stackoverflow.com/a/2267567/9567349
fix printing to screen twice (fix https://github.com/deepmodeling/dpdispatcher/issues/79#issuecomment-872556042)
