### PR TITLE
if meet permission error when dumping dpdispatcher.log, will try to redirect the log to ~/dpdispatcher.log

### DIFF
--- a/dpdispatcher/__init__.py
+++ b/dpdispatcher/__init__.py
@@ -1,12 +1,17 @@
 import logging
 import os, sys
-
+import warnings
 
 ROOT_PATH=__path__[0]
 dlog = logging.getLogger(__name__)
 dlog.propagate = False
 dlog.setLevel(logging.INFO)
-dlogf = logging.FileHandler(os.getcwd()+os.sep+'dpdispatcher'+'.log')
+try:
+    dlogf = logging.FileHandler(os.getcwd()+os.sep+'dpdispatcher'+'.log')
+except PermissionError:
+    warnings.warn(f"dpdispatcher.log meet permission error. redirect the log to ~/dpdispatcher.log")
+    dlogf = logging.logging.FileHandler(os.path.join(os.path.expanduser('~'),'dpdispatcher.log'))
+
 # dlogf = logging.FileHandler('./'+os.sep+SHORT_CMD+'.log')
 # dlogf = logging.FileHandler(os.path.join(os.environ['HOME'], SHORT_CMD+'.log'))
 # dlogf = logging.FileHandler(os.path.join(os.path.expanduser('~'), SHORT_CMD+'.log'))


### PR DESCRIPTION
if meet permission error when dumping dpdispatcher.log, will try to redirect the log to ~/dpdispatcher.log