### PR TITLE
Changed a few lines to adapt win system ssh context

### DIFF
--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -229,7 +229,7 @@ class Machine(object):
             single_script_command = script_command_template.format(
                 flag_if_job_task_fail=flag_if_job_task_fail,
                 command_env=command_env,
-                task_work_path=task.task_work_path,
+                task_work_path=task.task_work_path.replace('\\', '/'),
                 command=task.command,
                 task_tag_finished=task_tag_finished,
                 log_err_part=log_err_part)
@@ -284,7 +284,7 @@ class Machine(object):
     @staticmethod
     def arginfo():
         # TODO: change the possible value of batch and context types after we refactor the code
-        doc_batch_type = 'The batch job system type. Option: Slurm, PBS, LSF, Shell, DpCloudServer'
+        doc_batch_type = 'The batch job system type. Option: Slurm, PBS (for OpenPBS only), Torque (for Torque version of pbs), LSF, Shell, DpCloudServer'
         doc_context_type = 'The connection used to remote machine. Option: LocalContext, LazyLocalContext, SSHContext， DpCloudServerContext'
         doc_local_root = 'The dir where the tasks and relating files locate. Typically the project dir.'
         doc_remote_root = 'The dir where the tasks are executed on the remote machine. Only needed when context is not lazy-local.'


### PR DESCRIPTION
For windows system, the directory delimiter is '\'. However, in the linux system, it's '/'. When the workbase is set in windows, it may generate bugs. More specificlly, when you upload files, it's win path, we need to set task_work_path '\' in the input.json.
When you write .sub files, it must be a linux path. So the first change is in the machine.py file line 232.
When you download file, it must be a linux path. So the second change is in thessh_context.py file line 372.
And in dpgen,  after upload files, there is a unzip it, '/'. 
I'm a newbee in github, forgive my poor code grammar.(*￣︶￣)