### PR TITLE
add module purge, improve envs and upload oss path with random address.

### DIFF
--- a/dpdispatcher/__init__.py
+++ b/dpdispatcher/__init__.py
@@ -46,14 +46,14 @@ from .pbs import PBS
 from .pbs import Torque
 from .shell import Shell
 from .lsf import LSF
-from .dp_cloud_server import DpCloudServer
+from .dp_cloud_server import DpCloudServer, Lebesgue
 from .distributed_shell import DistributedShell
 from .machine import Machine
 
 from .lazy_local_context import LazyLocalContext
 from .local_context import LocalContext
 from .ssh_context import SSHContext
-from .dp_cloud_server_context import DpCloudServerContext
+from .dp_cloud_server_context import DpCloudServerContext, LebesgueContext
 from .hdfs_context import HDFSContext
 
 def info():

--- a/dpdispatcher/distributed_shell.py
+++ b/dpdispatcher/distributed_shell.py
@@ -46,6 +46,9 @@ class DistributedShell(Machine):
         source_files_part = ""
 
         module_unload_part = ""
+        module_purge = job.resources.module_purge
+        if module_purge:
+            module_unload_part += "module purge\n"
         module_unload_list = job.resources.module_unload_list
         for ii in module_unload_list:
             module_unload_part += f"module unload {ii}\n"
@@ -63,7 +66,11 @@ class DistributedShell(Machine):
         export_envs_part = ""
         envs = job.resources.envs
         for k, v in envs.items():
-            export_envs_part += f"export {k}={v}\n"
+            if isinstance(v, list):
+                for each_value in v:
+                    export_envs_part += f"export {k}={each_value}\n"
+            else:
+                export_envs_part += f"export {k}={v}\n"
 
         flag_if_job_task_fail = job.job_hash + '_flag_if_job_task_fail'
 

--- a/dpdispatcher/dp_cloud_server.py
+++ b/dpdispatcher/dp_cloud_server.py
@@ -182,5 +182,6 @@ class DpCloudServer(Machine):
     #     job_tag_finished = job.job_hash + '_job_tag_finished'
     #     return self.context.check_file_exists(job_tag_finished)
 
+
 class Lebesgue(DpCloudServer):
     pass

--- a/dpdispatcher/dp_cloud_server.py
+++ b/dpdispatcher/dp_cloud_server.py
@@ -6,6 +6,7 @@ from dpdispatcher.dpcloudserver.config import ALI_OSS_BUCKET_URL
 import time
 import warnings
 import os
+import uuid
 
 shell_script_header_template="""
 #!/bin/bash -l
@@ -60,10 +61,24 @@ class DpCloudServer(Machine):
             result_file_list.extend([ os.path.join(task.task_work_path,b_f) for b_f in task.backward_files])
         return result_file_list
 
+    def _gen_oss_path(self, job, zip_filename):
+        if hasattr(job, 'upload_path') and job.upload_path:
+            return job.upload_path
+        else:
+            program_id = self.context.remote_profile.get('program_id')
+            if program_id is None:
+                dlog.info("can not find program id in remote profile, upload to default program id.")
+                program_id = 0
+            uid = uuid.uuid4()
+            path = os.path.join("program", str(program_id), str(uid), zip_filename)
+            setattr(job, 'upload_path', path)
+            return path
+
     def do_submit(self, job):
         self.gen_local_script(job)
         zip_filename = job.job_hash + '.zip'
-        oss_task_zip = 'indicate/' + job.job_hash + '/' + zip_filename
+        # oss_task_zip = 'indicate/' + job.job_hash + '/' + zip_filename
+        oss_task_zip = self._gen_oss_path(job, zip_filename)
         job_resources = ALI_OSS_BUCKET_URL + oss_task_zip
 
         input_data = self.input_data.copy()
@@ -167,3 +182,5 @@ class DpCloudServer(Machine):
     #     job_tag_finished = job.job_hash + '_job_tag_finished'
     #     return self.context.check_file_exists(job_tag_finished)
 
+class Lebesgue(DpCloudServer):
+    pass

--- a/dpdispatcher/dp_cloud_server_context.py
+++ b/dpdispatcher/dp_cloud_server_context.py
@@ -149,9 +149,6 @@ class DpCloudServerContext(BaseContext):
             target_result_zip = os.path.join(self.local_root, result_filename)
             self.api.download_from_url(info['result_url'], target_result_zip)
             zip_file.unzip_file(target_result_zip, out_dir=self.local_root)
-            os.makedirs(os.path.join(self.local_root, 'backup'), exist_ok=True)
-            shutil.move(target_result_zip,
-                        os.path.join(self.local_root, 'backup', os.path.split(target_result_zip)[1]))
             try:
                 if self.remote_profile.get('keep_backup', True):
                     # move to backup directory

--- a/dpdispatcher/dp_cloud_server_context.py
+++ b/dpdispatcher/dp_cloud_server_context.py
@@ -7,9 +7,9 @@ from dargs.dargs import Argument
 from dpdispatcher.base_context import BaseContext
 from typing import List
 import os
-# from dpdispatcher import dlog
+from dpdispatcher import dlog
 # from dpdispatcher.submission import Machine
-from . import dlog
+# from . import dlog
 from .dpcloudserver.api import API
 from .dpcloudserver import zip_file
 import shutil

--- a/dpdispatcher/dp_cloud_server_context.py
+++ b/dpdispatcher/dp_cloud_server_context.py
@@ -255,4 +255,5 @@ class DpCloudServerContext(BaseContext):
 
 class LebesgueContext(DpCloudServerContext):
     pass
+
 #%%

--- a/dpdispatcher/dp_cloud_server_context.py
+++ b/dpdispatcher/dp_cloud_server_context.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 # coding: utf-8
 # %%
+import uuid
+
 from dargs.dargs import Argument
 from dpdispatcher.base_context import BaseContext
 from typing import List
 import os
 # from dpdispatcher import dlog
 # from dpdispatcher.submission import Machine
+from . import dlog
 from .dpcloudserver.api import API
 from .dpcloudserver import zip_file
+import shutil
 # from zip_file import zip_files
 DP_CLOUD_SERVER_HOME_DIR = os.path.join(
     os.path.expanduser('~'),
@@ -64,6 +68,18 @@ class DpCloudServerContext(BaseContext):
         #     file_uuid = uuid.uuid1().hex
         # oss_task_dir = os.path.join()
 
+    def _gen_oss_path(self, job, zip_filename):
+        if hasattr(job, 'upload_path') and job.upload_path:
+            return job.upload_path
+        else:
+            program_id = self.remote_profile.get('program_id')
+            if program_id is None:
+                program_id = 0
+            uid = uuid.uuid4()
+            path = os.path.join("program", str(program_id), str(uid), zip_filename)
+            setattr(job, 'upload_path', path)
+            return path
+
     def upload(self, submission):
         # oss_task_dir = os.path.join('%s/%s/%s.zip' % ('indicate', file_uuid, file_uuid))
         # zip_filename = submission.submission_hash + '.zip'
@@ -75,7 +91,7 @@ class DpCloudServerContext(BaseContext):
         for job in submission.belonging_jobs:
             self.machine.gen_local_script(job)
             zip_filename = job.job_hash + '.zip'
-            oss_task_zip = 'indicate/' + job.job_hash + '/' + zip_filename
+            oss_task_zip = self._gen_oss_path(job, zip_filename)
             zip_task_file = os.path.join(self.local_root, zip_filename)
 
             upload_file_list = [job.script_file_name, ]
@@ -95,6 +111,16 @@ class DpCloudServerContext(BaseContext):
                 file_list=upload_file_list
             )
             result = self.api.upload(oss_task_zip, upload_zip, ENDPOINT, BUCKET_NAME)
+            try:
+                if self.remote_profile.get('keep_backup', True):
+                    # move to backup directory
+                    os.makedirs(os.path.join(self.local_root, 'backup'), exist_ok=True)
+                    shutil.move(upload_zip,
+                                os.path.join(self.local_root, 'backup', os.path.split(upload_zip)[1]))
+                else:
+                    os.remove(upload_zip)
+            except Exception as e:
+                dlog.error("unable to backup file, " + str(e))
         return result
         # return oss_task_zip
         # api.upload(self.oss_task_dir, zip_task_file)
@@ -108,7 +134,7 @@ class DpCloudServerContext(BaseContext):
             if isinstance(job.job_id, str) and ':job_group_id:' in job.job_id:
                 ids = job.job_id.split(":job_group_id:")
                 jid, gid = int(ids[0]), int(ids[1])
-                job_hashs[jid] = job.job_hash 
+                job_hashs[jid] = job.job_hash
                 group_id = gid
             else:
                 job_infos[job.job_hash] = self.get_tasks(job.job_id)[0]
@@ -118,11 +144,24 @@ class DpCloudServerContext(BaseContext):
                 if 'result_url' in each and each['result_url'] != '' and each['status'] == 2:
                     job_hash = job_hashs[each['task_id']]
                     job_infos[job_hash] = each
-        for hash, info in job_infos.items():
-            result_filename = hash + '_back.zip'
+        for job_hash, info in job_infos.items():
+            result_filename = job_hash + '_back.zip'
             target_result_zip = os.path.join(self.local_root, result_filename)
             self.api.download_from_url(info['result_url'], target_result_zip)
             zip_file.unzip_file(target_result_zip, out_dir=self.local_root)
+            os.makedirs(os.path.join(self.local_root, 'backup'), exist_ok=True)
+            shutil.move(target_result_zip,
+                        os.path.join(self.local_root, 'backup', os.path.split(target_result_zip)[1]))
+            try:
+                if self.remote_profile.get('keep_backup', True):
+                    # move to backup directory
+                    os.makedirs(os.path.join(self.local_root, 'backup'), exist_ok=True)
+                    shutil.move(target_result_zip,
+                                os.path.join(self.local_root, 'backup', os.path.split(target_result_zip)[1]))
+                else:
+                    os.remove(target_result_zip)
+            except Exception as e:
+                dlog.error("unable to backup file, " + str(e))
         return True
 
     def write_file(self, fname, write_str):
@@ -212,4 +251,8 @@ class DpCloudServerContext(BaseContext):
                                                                          'None or empty.')
             ], optional=False, doc="Configuration of job"),
         ], doc=doc_remote_profile)]
+
+
+class LebesgueContext(DpCloudServerContext):
+    pass
 #%%

--- a/dpdispatcher/dp_cloud_server_context.py
+++ b/dpdispatcher/dp_cloud_server_context.py
@@ -139,7 +139,7 @@ class DpCloudServerContext(BaseContext):
                     if each['task_id'] not in job_hashs:
                         dlog.info(f"find unexpect job_hash, but task {each['task_id']} still been download.")
                         dlog.debug(str(job_hashs))
-                        job_hash = each['task_id']
+                        job_hash = str(each['task_id'])
                     else:
                         job_hash = job_hashs[each['task_id']]
                     job_infos[job_hash] = each

--- a/dpdispatcher/dp_cloud_server_context.py
+++ b/dpdispatcher/dp_cloud_server_context.py
@@ -161,7 +161,7 @@ class DpCloudServerContext(BaseContext):
             else:
                 os.remove(target)
         except (OSError, shutil.Error) as e:
-            dlog.error("unable to backup file, " + str(e))
+            dlog.exception("unable to backup file, " + str(e))
 
     def write_file(self, fname, write_str):
         result = self.write_home_file(fname, write_str)

--- a/dpdispatcher/dp_cloud_server_context.py
+++ b/dpdispatcher/dp_cloud_server_context.py
@@ -135,7 +135,13 @@ class DpCloudServerContext(BaseContext):
             job_result = self.api.get_tasks_v2_list(group_id)
             for each in job_result:
                 if 'result_url' in each and each['result_url'] != '' and each['status'] == 2:
-                    job_hash = job_hashs[each['task_id']]
+                    job_hash = ''
+                    if each['task_id'] not in job_hashs:
+                        dlog.info(f"find unexpect job_hash, but task {each['task_id']} still been download.")
+                        dlog.debug(str(job_hashs))
+                        job_hash = each['task_id']
+                    else:
+                        job_hash = job_hashs[each['task_id']]
                     job_infos[job_hash] = each
         for job_hash, info in job_infos.items():
             result_filename = job_hash + '_back.zip'

--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -181,6 +181,9 @@ class Machine(object):
         source_files_part = ""
 
         module_unload_part = ""
+        module_purge = job.resources.module_purge
+        if module_purge:
+            module_unload_part += "module purge\n"
         module_unload_list = job.resources.module_unload_list
         for ii in module_unload_list:
             module_unload_part += f"module unload {ii}\n"
@@ -198,7 +201,11 @@ class Machine(object):
         export_envs_part = ""
         envs = job.resources.envs
         for k,v in envs.items():
-            export_envs_part += f"export {k}={v}\n"
+            if isinstance(v, list):
+                for each_value in v:
+                    export_envs_part += f"export {k}={each_value}\n"
+            else:
+                export_envs_part += f"export {k}={v}\n"
 
         flag_if_job_task_fail = job.job_hash + '_flag_if_job_task_fail'
 

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -649,6 +649,7 @@ class Resources(object):
                 strategy=default_strategy,
                 para_deg=1,
                 module_unload_list=[],
+                module_purge=False,
                 module_list=[],
                 source_list=[],
                 envs={},
@@ -663,6 +664,7 @@ class Resources(object):
         self.custom_flags = custom_flags
         self.strategy = strategy
         self.para_deg = para_deg
+        self.module_purge = module_purge
         self.module_unload_list = module_unload_list
         self.module_list = module_list
         self.source_list = source_list
@@ -697,6 +699,7 @@ class Resources(object):
         resources_dict['custom_flags'] = self.custom_flags
         resources_dict['strategy'] = self.strategy
         resources_dict['para_deg'] = self.para_deg
+        resources_dict['module_purge'] = self.module_purge
         resources_dict['module_unload_list'] = self.module_unload_list
         resources_dict['module_list'] = self.module_list
         resources_dict['source_list'] = self.source_list
@@ -715,6 +718,7 @@ class Resources(object):
                         custom_flags=resources_dict.get('custom_flags', []),
                         strategy=resources_dict.get('strategy', default_strategy),
                         para_deg=resources_dict.get('para_deg', 1),
+                        module_purge=resources_dict.get('module_purge', False),
                         module_unload_list=resources_dict.get('module_unload_list', []),
                         module_list=resources_dict.get('module_list', []),
                         source_list=resources_dict.get('source_list', []),
@@ -747,6 +751,7 @@ class Resources(object):
         doc_custom_flags = 'The extra lines pass to job submitting script header'
         doc_para_deg = 'Decide how many tasks will be run in parallel.'
         doc_source_list = 'The env file to be sourced before the command execution.'
+        doc_module_purge = 'Remove all modules on HPC system before module load (module_list)'
         doc_module_unload_list = 'The modules to be unloaded on HPC system before submitting jobs'
         doc_module_list = 'The modules to be loaded on HPC system before submitting jobs'
         doc_envs = 'The environment variables to be exported on before submitting jobs'
@@ -769,6 +774,7 @@ class Resources(object):
             strategy_format,
             Argument("para_deg", int, optional=True, doc=doc_para_deg, default=1),
             Argument("source_list", list, optional=True, doc=doc_source_list, default=[]),
+            Argument("module_purge", bool, optional=True, doc=doc_module_purge, default=False),
             Argument("module_unload_list", list, optional=True, doc=doc_module_unload_list, default=[]),
             Argument("module_list", list, optional=True, doc=doc_module_list, default=[]),
             Argument("envs", dict, optional=True, doc=doc_envs, default={}),

--- a/tests/jsons/resources.json
+++ b/tests/jsons/resources.json
@@ -9,7 +9,6 @@
         "if_cuda_multi_devices": false
     },
     "para_deg": 1,
-    "module_purge": false,
     "module_unload_list": [],
     "module_list": [],
     "source_list": [],

--- a/tests/jsons/resources.json
+++ b/tests/jsons/resources.json
@@ -9,6 +9,7 @@
         "if_cuda_multi_devices": false
     },
     "para_deg": 1,
+    "module_purge": false,
     "module_unload_list": [],
     "module_list": [],
     "source_list": [],

--- a/tests/sample_class.py
+++ b/tests/sample_class.py
@@ -42,6 +42,7 @@ class SampleClass(object):
             'custom_flags':[],
             'strategy':{'if_cuda_multi_devices': False}, 
             'para_deg':1,
+            'module_purge':False,
             'module_unload_list':[],
             'module_list':[],
             'source_list':[],


### PR DESCRIPTION
The envs argument now accepts list and variable. 
before I have to write：
{
 "envs":{
    “LD_LIBRARY_PATH”：”/public/home/ac46q4orcq/dp-2.0/deepmd_root/lib:/public/home/ac46q4orcq/dp-2.0/tensorflow_root/lib:$LD_LIBRARY_PATH“
  }
}

now it can write as :

{
 "envs":{
    “LD_LIBRARY_PATH”：[
         ”/public/home/ac46q4orcq/dp-2.0/deepmd_root/lib:$LD_LIBRARY_PATH“,
         "/public/home/ac46q4orcq/dp-2.0/tensorflow_root/lib:$LD_LIBRARY_PATH"
  }
}
