### PR TITLE
add wait_time to Resources for delayed submission

### DIFF
--- a/.github/workflows/mirror_gitee.yml
+++ b/.github/workflows/mirror_gitee.yml
@@ -9,6 +9,7 @@ concurrency:
 jobs:
   git-mirror:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'deepmodeling'
     steps:
       - uses: wearerequired/git-mirror-action@v1
         env:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -572,6 +572,8 @@ class Job(object):
             self.submit_job()
             if self.job_state != JobStatus.unsubmitted:
                 dlog.info("job: {job_hash} submit; job_id is {job_id}".format(job_hash=self.job_hash, job_id=self.job_id))
+            if self.resources.wait_time != 0:
+                time.sleep(self.resources.wait_time)
             # self.get_job_state()
 
     def get_hash(self):
@@ -647,6 +649,8 @@ class Resources(object):
         Usually run with `strategy['if_cuda_multi_devices']`
     source_list : list of Path
         The env file to be sourced before the command execution.
+    wait_time : int
+        The waitting time in second after a single task submitted. Default: 0.
     """
     def __init__(self,
                 number_node,
@@ -663,6 +667,7 @@ class Resources(object):
                 module_list=[],
                 source_list=[],
                 envs={},
+                wait_time=0,
                 **kwargs):
         self.number_node = number_node
         self.cpu_per_node = cpu_per_node
@@ -679,6 +684,7 @@ class Resources(object):
         self.module_list = module_list
         self.source_list = source_list
         self.envs = envs
+        self.wait_time = wait_time
         # self.if_cuda_multi_devices = if_cuda_multi_devices
 
         self.kwargs = kwargs.get('kwargs', kwargs)
@@ -714,6 +720,7 @@ class Resources(object):
         resources_dict['module_list'] = self.module_list
         resources_dict['source_list'] = self.source_list
         resources_dict['envs'] = self.envs
+        resources_dict['wait_time'] = self.wait_time
         resources_dict['kwargs'] = self.kwargs
         return resources_dict
 
@@ -733,6 +740,7 @@ class Resources(object):
                         module_list=resources_dict.get('module_list', []),
                         source_list=resources_dict.get('source_list', []),
                         envs=resources_dict.get('envs', {}),
+                        wait_time=resources_dict.get('wait_time', 0),
                         **resources_dict.get('kwargs', {})
                         )
         return resources
@@ -765,6 +773,7 @@ class Resources(object):
         doc_module_unload_list = 'The modules to be unloaded on HPC system before submitting jobs'
         doc_module_list = 'The modules to be loaded on HPC system before submitting jobs'
         doc_envs = 'The environment variables to be exported on before submitting jobs'
+        doc_wait_time = 'The waitting time in second after a single `task` submitted'
 
         strategy_args = [
             Argument("if_cuda_multi_devices", bool, optional=True, default=True)
@@ -788,6 +797,7 @@ class Resources(object):
             Argument("module_unload_list", list, optional=True, doc=doc_module_unload_list, default=[]),
             Argument("module_list", list, optional=True, doc=doc_module_list, default=[]),
             Argument("envs", dict, optional=True, doc=doc_envs, default={}),
+            Argument("wait_time", int, optional=True, doc=doc_wait_time, default=0)
         ]
 
         batch_variant = Variant(

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -797,7 +797,7 @@ class Resources(object):
             Argument("module_unload_list", list, optional=True, doc=doc_module_unload_list, default=[]),
             Argument("module_list", list, optional=True, doc=doc_module_list, default=[]),
             Argument("envs", dict, optional=True, doc=doc_envs, default={}),
-            Argument("wait_time", int, optional=True, doc=doc_wait_time, default=0)
+            Argument("wait_time", [int, float], optional=True, doc=doc_wait_time, default=0)
         ]
 
         batch_variant = Variant(

--- a/tests/jsons/resources.json
+++ b/tests/jsons/resources.json
@@ -13,5 +13,6 @@
     "module_list": [],
     "source_list": [],
     "envs": {},
+    "wait_time": 0,
     "kwargs": {}
 }

--- a/tests/sample_class.py
+++ b/tests/sample_class.py
@@ -47,6 +47,7 @@ class SampleClass(object):
             'module_list':[],
             'source_list':[],
             'envs':{},
+            'wait_time': 0,
             'kwargs': {}
         }
         return resources_dict


### PR DESCRIPTION
For some special queue or host, job submission might require waiting time after each single job submitted, to prevent crash when tasks were submitted together. Therefore, parameter `wait_time` is added to `Resources`, to support the special issue. 

The default value of `wait_time` is 0, and it accepts a value of `int`. If set to a value larger than 0, it will sleep for `wait_time` seconds after each job submission. 

Also, a condition is added for `mirror_gitee` action to prevent error message after pushing to the forked repository instead of the main one.