### PR TITLE
 hash/compare from `json.dumps`

### DIFF
--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -63,7 +63,7 @@ class Submission(object):
         """When check whether the two submission are equal,
         we disregard the runtime infomation(job_state, job_id, fail_count) of the submission.belonging_jobs.
         """
-        return self.serialize(if_static=True) == other.serialize(if_static=True)
+        return json.dumps(self.serialize(if_static=True)) == json.dumps(other.serialize(if_static=True))
 
     def __getitem__(self, key):
         return self.serialize()[key]
@@ -399,7 +399,7 @@ class Task(object):
         return str(self.serialize())
 
     def __eq__(self, other):
-        return self.serialize() == other.serialize()
+        return json.dumps(self.serialize()) == json.dumps(other.serialize())
 
     def __getitem__(self, key):
         return self.serialize()[key]
@@ -504,7 +504,7 @@ class Job(object):
         """When check whether the two jobs are equal,
         we disregard the runtime infomation(job_state, job_id, fail_count) of the jobs.
         """
-        return self.serialize(if_static=True) == other.serialize(if_static=True)
+        return json.dumps(self.serialize(if_static=True)) == json.dumps(other.serialize(if_static=True))
 
     @classmethod
     def deserialize(cls, job_dict, machine=None):
@@ -704,7 +704,7 @@ class Resources(object):
                 raise RuntimeError("number_node must be 1 when if_cuda_multi_devices is True")
 
     def __eq__(self, other):
-        return self.serialize() == other.serialize()
+        return json.dumps(self.serialize()) == json.dumps(other.serialize())
 
     def serialize(self):
         resources_dict = {}

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -137,8 +137,9 @@ class Submission(object):
             raise RuntimeError("Not allowed to register tasks after generating jobs."
                     "submission hash error {self}".format(self=self))
         self.belonging_tasks.extend(task_list)
+
     def get_hash(self):
-        return sha1(str(self.serialize(if_static=True)).encode('utf-8')).hexdigest()
+        return sha1(json.dumps(self.serialize(if_static=True)).encode('utf-8')).hexdigest()
 
     def bind_machine(self, machine):
         """bind this submission to a machine. update the machine's context remote_root and local_root.
@@ -404,7 +405,7 @@ class Task(object):
         return self.serialize()[key]
 
     def get_hash(self):
-        return sha1(str(self.serialize()).encode('utf-8')).hexdigest()
+        return sha1(json.dumps(self.serialize()).encode('utf-8')).hexdigest()
 
     @classmethod
     def load_from_json(cls, json_file):
@@ -598,7 +599,7 @@ class Job(object):
         job_content_dict['job_task_list'] = [ task.serialize() for task in self.job_task_list ]
         job_content_dict['resources'] = self.resources.serialize()
         # job_content_dict['job_work_base'] = self.job_work_base
-        job_hash = sha1(str(job_content_dict).encode('utf-8')).hexdigest()
+        job_hash = sha1(json.dumps(job_content_dict).encode('utf-8')).hexdigest()
         if not if_static:
             job_content_dict['job_state'] = self.job_state
             job_content_dict['job_id'] = self.job_id


### PR DESCRIPTION
 `json.dumps` should be safer to obtain consistent string.