### PR TITLE
Support optional compress for SSHContext 

### DIFF
--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -378,7 +378,7 @@ class SSHContext(BaseContext):
             # convert to relative path to local_root
             file_list = [os.path.relpath(jj, self.local_root) for jj in file_list] 
 
-        self._put_files(file_list, dereference = dereference, directories=directory_list)
+        self._put_files(file_list, dereference = dereference, directories=directory_list, tar_compress = self.remote_profile.get('tar_compress', None))
         os.chdir(cwd)
 
     def download(self, 
@@ -410,7 +410,7 @@ class SSHContext(BaseContext):
                 file_list.extend(errors)
         file_list.extend(submission.backward_common_files)
         if len(file_list) > 0:
-            self._get_files(file_list)
+            self._get_files(file_list, tar_compress = self.remote_profile.get('tar_compress', None))
         os.chdir(cwd)
         
     def block_checkcall(self, 
@@ -513,6 +513,7 @@ class SSHContext(BaseContext):
                    files,
                    dereference = True,
                    directories = None,
+                   tar_compress = True,
                    ) :
         """Upload files to server.
 
@@ -527,21 +528,31 @@ class SSHContext(BaseContext):
         directories: list, default: None
             uploaded directories non-recursively. Use `files` for uploading
             recursively
+        tar_compress: bool, default: True
+            If tar_compress is True, compress the archive using gzip
+            It it is False, then it is uncompressed
         """
-        of = self.submission.submission_hash + '.tgz'
+        of_suffix = '.tgz'
+        tarfile_mode = 'w:gz'
+        tarfile_compresslevel = 6
+        if not tar_compress :
+            of_suffix = '.tar'
+            tarfile_mode = 'w'
+            tarfile_compresslevel = None
+                    
+        of = self.submission.submission_hash + of_suffix
         # local tar
         cwd = os.getcwd()
         os.chdir(self.local_root)
         if os.path.isfile(of) :
             os.remove(of)
-        with tarfile.open(of, "w:gz", dereference = dereference, compresslevel=6) as tar:
+        with tarfile.open(of, mode = tarfile_mode, dereference = dereference, compresslevel = tarfile_compresslevel) as tar:
             for ii in files :
                 tar.add(ii)
             if directories is not None:
                 for ii in directories:
                     tar.add(ii, recursive=False)
         os.chdir(cwd)
-
         self.ssh_session.ensure_alive()
         try:
             self.sftp.mkdir(self.remote_root)
@@ -561,19 +572,29 @@ class SSHContext(BaseContext):
         self.sftp.remove(to_f)
 
     def _get_files(self, 
-                   files) :
-        of = self.submission.submission_hash + '.tar.gz'
+                   files,
+                   tar_compress = True) :
+        
+        of_suffix = '.tar.gz'
+        tarfile_mode = 'r:gz'
+        tar_command = 'czfh'
+        if not tar_compress :
+            of_suffix = '.tar'
+            tarfile_mode = 'r'
+            tar_command = 'cfh'
+
+        of = self.submission.submission_hash + of_suffix
         # remote tar
         # If the number of files are large, we may get "Argument list too long" error.
         # Thus, "-T" accepts a file containing the list of files
         per_nfile = 100
         ntar = len(files) // per_nfile + 1
         if ntar <= 1:
-            self.block_checkcall('tar czfh %s %s' % (of, " ".join(files)))
+            self.block_checkcall('tar %s %s %s' % (tar_command, of, " ".join(files)))
         else:
             file_list_file = os.path.join(self.remote_root, ".tmp.tar." + str(uuid.uuid4()))
             self.write_file(file_list_file, "\n".join(files))
-            self.block_checkcall('tar czfh %s -T %s' % (of, file_list_file))
+            self.block_checkcall('tar %s %s -T %s' % (tar_command, of, file_list_file))
         # trans
         from_f = pathlib.PurePath(os.path.join(self.remote_root, of)).as_posix()
         to_f = pathlib.PurePath(os.path.join(self.local_root, of)).as_posix()
@@ -583,9 +604,9 @@ class SSHContext(BaseContext):
         # extract
         cwd = os.getcwd()
         os.chdir(self.local_root)
-        with tarfile.open(of, "r:gz") as tar:
+        with tarfile.open(of, mode = tarfile_mode) as tar:
             tar.extractall()
-        os.chdir(cwd)        
+        os.chdir(cwd)    
         # cleanup
         os.remove(to_f)
         self.sftp.remove(from_f)

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -543,7 +543,7 @@ class SSHContext(BaseContext):
         if not tar_compress :
             of_suffix = '.tar'
             tarfile_mode = 'w'
-            tarfile_compresslevel = None
+            tarfile_compresslevel = 0
                     
         of = self.submission.submission_hash + of_suffix
         # local tar

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -551,7 +551,7 @@ class SSHContext(BaseContext):
         os.chdir(self.local_root)
         if os.path.isfile(of) :
             os.remove(of)
-        with tarfile.open(of, mode = tarfile_mode, dereference = dereference, compresslevel = tarfile_compresslevel) as tar:
+        with tarfile.open(of, tarfile_mode, dereference = dereference, compresslevel=int(tarfile_compresslevel)) as tar:
             for ii in files :
                 tar.add(ii)
             if directories is not None:

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -28,6 +28,7 @@ class SSHSession (object):
                 passphrase=None,
                 timeout=10,
                 totp_secret=None,
+                tar_compress=True
                 ):
 
         self.hostname = hostname
@@ -39,6 +40,7 @@ class SSHSession (object):
         self.timeout = timeout
         self.totp_secret = totp_secret
         self.ssh = None
+        self.tar_compress = tar_compress
         self._setup_ssh()
 
     # @classmethod
@@ -115,7 +117,7 @@ class SSHSession (object):
         self.ssh.connect(hostname=self.hostname, port=self.port,
                         username=self.username, password=self.password,
                         key_filename=self.key_filename, timeout=self.timeout,passphrase=self.passphrase,
-                        compress=True,
+                        compress=self.tar_compress,
                         )
         assert(self.ssh.get_transport().is_active())
         transport = self.ssh.get_transport()
@@ -166,6 +168,7 @@ class SSHSession (object):
         doc_timeout = 'timeout of ssh connection'
         doc_totp_secret = 'Time-based one time password secret. It should be a base32-encoded string' \
                           ' extracted from the 2D code.'
+        doc_tar_compress = 'If it is True, the archieve will be compressed.'
 
         ssh_remote_profile_args = [
             Argument("hostname", str, optional=False, doc=doc_hostname),
@@ -176,6 +179,7 @@ class SSHSession (object):
             Argument("passphrase", [str, None], optional=True, default=None, doc=doc_passphrase),
             Argument("timeout", int, optional=True, default=10, doc=doc_timeout),
             Argument("totp_secret", str, optional=True, default=None, doc=doc_totp_secret),
+            Argument("tar_compress", bool, optional=True, default=True, doc = doc_tar_compress),
         ]
         ssh_remote_profile_format = Argument("ssh_session", dict, ssh_remote_profile_args)
         return ssh_remote_profile_format
@@ -246,6 +250,7 @@ class SSHContext(BaseContext):
         #     key_filename = jdata.get('key_filename', None),
         #     passphrase = jdata.get('passphrase', None),
         #     timeout = jdata.get('timeout', 10),
+        #     tar_compress = jdata.get('tar_compress', True)
         # )
         local_root = context_dict['local_root']
         remote_root = context_dict['remote_root']

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -538,11 +538,11 @@ class SSHContext(BaseContext):
             It it is False, then it is uncompressed
         """
         of_suffix = '.tgz'
-        tarfile_mode = 'w:gz'
+        tarfile_mode = "w:gz"
         tarfile_compresslevel = 6
         if not tar_compress :
             of_suffix = '.tar'
-            tarfile_mode = 'w'
+            tarfile_mode = "w"
             tarfile_compresslevel = 0
                     
         of = self.submission.submission_hash + of_suffix
@@ -581,11 +581,11 @@ class SSHContext(BaseContext):
                    tar_compress = True) :
         
         of_suffix = '.tar.gz'
-        tarfile_mode = 'r:gz'
+        tarfile_mode = "r:gz"
         tar_command = 'czfh'
         if not tar_compress :
             of_suffix = '.tar'
-            tarfile_mode = 'r'
+            tarfile_mode = "r"
             tar_command = 'cfh'
 
         of = self.submission.submission_hash + of_suffix

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -539,11 +539,11 @@ class SSHContext(BaseContext):
         """
         of_suffix = '.tgz'
         tarfile_mode = "w:gz"
-        tarfile_compresslevel = 6
+        kwargs = {'compresslevel': 6}
         if not tar_compress :
             of_suffix = '.tar'
             tarfile_mode = "w"
-            tarfile_compresslevel = 0
+            kwargs = {}
                     
         of = self.submission.submission_hash + of_suffix
         # local tar
@@ -551,7 +551,7 @@ class SSHContext(BaseContext):
         os.chdir(self.local_root)
         if os.path.isfile(of) :
             os.remove(of)
-        with tarfile.open(of, tarfile_mode, dereference = dereference, compresslevel=int(tarfile_compresslevel)) as tar:
+        with tarfile.open(of, tarfile_mode, dereference = dereference, **kwargs) as tar:
             for ii in files :
                 tar.add(ii)
             if directories is not None:

--- a/tests/test_ssh_context.py
+++ b/tests/test_ssh_context.py
@@ -109,7 +109,7 @@ class TestSSHContext(unittest.TestCase):
         self.context.download(self.__class__.submission)
 
     def test_tar_compress(self):
-        self.machine["remote_profile"]["tar_compress"] = False
+        self.machine.context.remote_profile['tar_compress'] = False
         self.context.upload(self.__class__.submission)
         check_file_list = ['graph.pb', 'bct-1/conf.lmp', 'bct-4/input.lammps']
         for file in check_file_list:

--- a/tests/test_ssh_context.py
+++ b/tests/test_ssh_context.py
@@ -108,12 +108,58 @@ class TestSSHContext(unittest.TestCase):
     def test_download(self):
         self.context.download(self.__class__.submission)
 
-    def test_tar_compress(self):
-        self.context.remote_profile['tar_compress'] = False
+class TestSSHContextNoCompress(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = mock_server()
+        host, port, username, workdir, key_filename = next(cls.server)
+        mdata = {
+            "batch_type": "Shell",
+            "context_type": "SSHContext",
+            "local_root": "./test_context_dir",
+            "remote_root": workdir,
+            "remote_profile": {
+                "hostname": host,
+                "port": port,
+                "username": username,
+                "key_filename": key_filename,
+                "tar_compress": False,
+            },
+        }
+        try:
+            cls.machine = Machine.load_from_dict(mdata)
+        except (SSHException, socket.timeout):
+            raise unittest.SkipTest("SSHException ssh cannot connect")
+        cls.submission = SampleClass.get_sample_submission()
+        cls.submission.bind_machine(cls.machine)
+        cls.submission_hash = cls.submission.submission_hash
+        file_list = ['bct-1/log.lammps', 'bct-2/log.lammps', 'bct-3/log.lammps', 'bct-4/log.lammps']
+        for file in file_list:
+            cls.machine.context.sftp.mkdir(os.path.join(cls.machine.context.remote_root, os.path.dirname(file)))
+            cls.machine.context.write_file(file, '# mock log')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.machine.context.clean()
+        # close the server
+        cls.machine.context.close()
+        next(cls.server)
+    
+    def setUp(self):
+        self.context = self.__class__.machine.context
+
+    def test_ssh_session(self):
+        self.assertIsInstance(
+            self.__class__.machine.context.ssh_session, SSHSession
+        )
+
+    def test_upload(self):
         self.context.upload(self.__class__.submission)
         check_file_list = ['graph.pb', 'bct-1/conf.lmp', 'bct-4/input.lammps']
         for file in check_file_list:
             self.assertTrue(self.context.check_file_exists(os.path.join(self.context.remote_root, file)))
+
+    def test_download(self):
         self.context.download(self.__class__.submission)
         
 

--- a/tests/test_ssh_context.py
+++ b/tests/test_ssh_context.py
@@ -107,6 +107,14 @@ class TestSSHContext(unittest.TestCase):
 
     def test_download(self):
         self.context.download(self.__class__.submission)
+
+    def test_tar_compress(self):
+        self.machine["remote_profile"]["tar_compress"] = False
+        self.context.upload(self.__class__.submission)
+        check_file_list = ['graph.pb', 'bct-1/conf.lmp', 'bct-4/input.lammps']
+        for file in check_file_list:
+            self.assertTrue(self.context.check_file_exists(os.path.join(self.context.remote_root, file)))
+        self.context.download(self.__class__.submission)
         
 
 

--- a/tests/test_ssh_context.py
+++ b/tests/test_ssh_context.py
@@ -109,7 +109,7 @@ class TestSSHContext(unittest.TestCase):
         self.context.download(self.__class__.submission)
 
     def test_tar_compress(self):
-        self.machine.context.remote_profile['tar_compress'] = False
+        self.context.remote_profile['tar_compress'] = False
         self.context.upload(self.__class__.submission)
         check_file_list = ['graph.pb', 'bct-1/conf.lmp', 'bct-4/input.lammps']
         for file in check_file_list:


### PR DESCRIPTION
For a large number of small files, compression can be very CPU-intensive and time-consuming. See https://github.com/deepmodeling/dpgen/issues/766. 
Add `tar_compress` in dict `remote_profile`. The archive will be compressed in upload and download if it is True. If not, compression will be skipped. 