### PR TITLE
comment python 3.8 tests; add 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,9 @@ jobs:
       matrix:
         python-version:
           - 3.7
-          - 3.8
+          #- 3.8
           - 3.9
+          - 3.10
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           - 3.7
           #- 3.8
           - 3.9
-          - 3.10
+          - '3.10'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
For unclear reasons, only Python 3.8 sometimes hangs forever.

Though, I cannot reproduce it on the local machine.