### PR TITLE
Fix: NoneType Error on DPCloudServer

### DIFF
--- a/dpdispatcher/dp_cloud_server.py
+++ b/dpdispatcher/dp_cloud_server.py
@@ -122,7 +122,7 @@ class DpCloudServer(Machine):
         # print("api",self.api_version,self.input_data.get('job_group_id'),job.job_id)
         check_return = self.api.get_tasks(job_id,group_id)
         try:
-            if isinstance(check_return["status"], type(None)):
+            if check_return is None:
                 return JobStatus.terminated
             dp_job_status = check_return["status"]
         except IndexError as e:

--- a/dpdispatcher/dp_cloud_server.py
+++ b/dpdispatcher/dp_cloud_server.py
@@ -122,7 +122,7 @@ class DpCloudServer(Machine):
         # print("api",self.api_version,self.input_data.get('job_group_id'),job.job_id)
         check_return = self.api.get_tasks(job_id,group_id)
         try:
-            if check_return["status"] is None:
+            if isinstance(check_return["status"], type(None)):
                 return JobStatus.terminated
             dp_job_status = check_return["status"]
         except IndexError as e:

--- a/dpdispatcher/dp_cloud_server.py
+++ b/dpdispatcher/dp_cloud_server.py
@@ -122,6 +122,8 @@ class DpCloudServer(Machine):
         # print("api",self.api_version,self.input_data.get('job_group_id'),job.job_id)
         check_return = self.api.get_tasks(job_id,group_id)
         try:
+            if check_return["status"] is None:
+                return JobStatus.terminated
             dp_job_status = check_return["status"]
         except IndexError as e:
             dlog.error(f"cannot find job information in bohrium for job {job.job_id}. check_return:{check_return}; retry one more time after 60 seconds")

--- a/dpdispatcher/dp_cloud_server.py
+++ b/dpdispatcher/dp_cloud_server.py
@@ -122,8 +122,7 @@ class DpCloudServer(Machine):
         # print("api",self.api_version,self.input_data.get('job_group_id'),job.job_id)
         check_return = self.api.get_tasks(job_id,group_id)
         try:
-            if check_return is None:
-                return JobStatus.unsubmitted
+            assert (check_return is not None), "Failed to get tasks. To resubmit this job, please delete uuid.json and try again.\nYou can check submission.submission_hash in the previous log, then try command:\n    rm -r ~/.dpdispatcher/dp_cloud_server/<submission.submission_hash>.json"
             dp_job_status = check_return["status"]
         except IndexError as e:
             dlog.error(f"cannot find job information in bohrium for job {job.job_id}. check_return:{check_return}; retry one more time after 60 seconds")

--- a/dpdispatcher/dp_cloud_server.py
+++ b/dpdispatcher/dp_cloud_server.py
@@ -123,7 +123,7 @@ class DpCloudServer(Machine):
         check_return = self.api.get_tasks(job_id,group_id)
         try:
             if check_return is None:
-                return JobStatus.terminated
+                return JobStatus.unsubmitted
             dp_job_status = check_return["status"]
         except IndexError as e:
             dlog.error(f"cannot find job information in bohrium for job {job.job_id}. check_return:{check_return}; retry one more time after 60 seconds")


### PR DESCRIPTION
After deleting a job group manually on bohrium, a NoneType error will be raised when submitting the job in the same path. To solve this problem, I add a check to NoneType and a note to help the user submit the job again.
(Only the last commit in this pr is applied.)