### PR TITLE
Enlarge banner timout

### DIFF
--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -127,6 +127,7 @@ class SSHSession (object):
 
         #Make a Paramiko Transport object using the socket
         ts = paramiko.Transport(sock)
+        ts.banner_timeout = 60
         ts.use_compression(compress=True)
 
         #Tell Paramiko that the Transport is going to be used as a client


### PR DESCRIPTION
This PR tends to solve  https://github.com/deepmodeling/dpdispatcher/issues/244 the ssh banner timeout error when using in high concurrency scenario. I enlarge the banner timout parameter from the default 15 to 60.