### PR TITLE
change source of mock-ssh-server; uncomment 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version:
           - 3.7
-          #- 3.8
+          - 3.8
           - 3.9
           - '3.10'
     steps:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "cloudserver": ["oss2", "tqdm"],
         ":python_version<'3.7'": ["typing_extensions"],
         "test": [
-            "https://github.com/njzjz/mock-ssh-server/archive/refs/heads/dpdispatcher.tar.gz",
+            "mock-ssh-server @ https://github.com/njzjz/mock-ssh-server/archive/refs/heads/dpdispatcher.tar.gz",
         ],
     },
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setuptools.setup(
         "cloudserver": ["oss2", "tqdm"],
         ":python_version<'3.7'": ["typing_extensions"],
         "test": [
-            "mock-ssh-server",
+            "https://github.com/njzjz/mock-ssh-server/archive/refs/heads/dpdispatcher.tar.gz",
         ],
     },
         entry_points={


### PR DESCRIPTION
The original package is patched in https://github.com/njzjz/mock-ssh-server/commit/646b6c9031b4e7e6685ce4142014d0ab10a07a86 to close `Popen`.