### PR TITLE
fix codecov

### DIFF
--- a/ci/pbs.sh
+++ b/ci/pbs.sh
@@ -9,6 +9,6 @@ cd -
 docker exec pbs_master /bin/bash -c "chmod -R 777 /shared_space"
 docker exec pbs_master /bin/bash -c "chown -R pbsuser:pbsuser /home/pbsuser"
 
-docker exec pbs_master /bin/bash -c "cd /dpdispatcher && pip install .[test] coverage codecov && chown -R pbsuser ."
+docker exec pbs_master /bin/bash -c "cd /dpdispatcher && pip install .[test] coverage && chown -R pbsuser ."
 docker exec -u pbsuser pbs_master /bin/bash -c "cd /dpdispatcher && coverage run --source=./dpdispatcher -m unittest -v && coverage report"
-docker exec -u pbsuser --env-file <(env | grep GITHUB) pbs_master /bin/bash -c "cd /dpdispatcher && codecov"
+docker exec -u pbsuser --env-file <(env | grep GITHUB) pbs_master /bin/bash -c "cd /dpdispatcher && curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov"

--- a/ci/slurm.sh
+++ b/ci/slurm.sh
@@ -7,4 +7,4 @@ docker-compose pull
 cd -
 
 docker exec slurmctld /bin/bash -c "cd dpdispatcher && pip install .[test] coverage && coverage run --source=./dpdispatcher -m unittest -v && coverage report"
-docker exec --env-file <(env | grep GITHUB) slurmctld /bin/bash -c "cd dpdispatcher && pip install codecov && codecov"
+docker exec --env-file <(env | grep GITHUB) slurmctld /bin/bash -c "cd dpdispatcher && curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov"

--- a/ci/ssh.sh
+++ b/ci/ssh.sh
@@ -7,4 +7,4 @@ docker-compose pull
 cd -
 
 docker exec test /bin/bash -c "cd /dpdispatcher && pip install .[test] coverage && coverage run --source=./dpdispatcher -m unittest -v && coverage report"
-docker exec --env-file <(env | grep GITHUB) test /bin/bash -c "cd /dpdispatcher && pip install codecov && codecov"
+docker exec --env-file <(env | grep GITHUB) test /bin/bash -c "cd /dpdispatcher && curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov"

--- a/ci/ssh_rsync.sh
+++ b/ci/ssh_rsync.sh
@@ -11,4 +11,4 @@ docker exec server /bin/bash -c "apt-get -y update && apt-get -y install rsync"
 docker exec test /bin/bash -c "apt-get -y update && apt-get -y install rsync"
 
 docker exec test /bin/bash -c "cd /dpdispatcher && pip install .[test] coverage && coverage run --source=./dpdispatcher -m unittest -v && coverage report"
-docker exec --env-file <(env | grep GITHUB) test /bin/bash -c "cd /dpdispatcher && pip install codecov && codecov"
+docker exec --env-file <(env | grep GITHUB) test /bin/bash -c "cd /dpdispatcher && curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov"


### PR DESCRIPTION
Codecov python package is deprecated does not work any more. This patch migrates it to another version.