### PR TITLE
Add retry for "Invalid user for SlurmUser"

### DIFF
--- a/dpdispatcher/slurm.py
+++ b/dpdispatcher/slurm.py
@@ -115,6 +115,7 @@ class Slurm(Machine):
             elif (
                 "Socket timed out on send/recv operation" in err_str
                 or "Unable to contact slurm controller" in err_str
+                or "Invalid user for SlurmUser" in err_str
             ):
                 # retry 3 times
                 raise RetrySignal(


### PR DESCRIPTION
The `squeue` command occasionally raises the error message `Invalid user for SlurmUser slurm, ignored`. This issue may be related to the network connectivity and is typically resolved within a few seconds. It appears that the error could be misleading, as it could be caused by a temporary network issue rather than a genuine account problem.

As a temporary solution, it would be helpful to modify the code to handle this scenario more gracefully. Instead of raising an error, I just add a condition that triggers a `RetrySignal` in case of the mentioned error. This approach should help distinguish between actual network and account issues. By implementing this change and allowing for three retries, we can likely resolve the problem without causing conflicts with genuine network or account issues.