### PR TITLE
refactor job kill

### DIFF
--- a/dpdispatcher/base_context.py
+++ b/dpdispatcher/base_context.py
@@ -70,9 +70,6 @@ class BaseContext(metaclass=ABCMeta):
     def read_file(self, fname):
         raise NotImplementedError("abstract method")
 
-    def kill(self, proc):
-        raise NotImplementedError("abstract method")
-
     def check_finish(self, proc):
         raise NotImplementedError("abstract method")
 

--- a/dpdispatcher/dp_cloud_server_context.py
+++ b/dpdispatcher/dp_cloud_server_context.py
@@ -270,9 +270,6 @@ class BohriumContext(BaseContext):
     #         retcode = cmd_pipes['stdout'].channel.recv_exit_status()
     #         return retcode, cmd_pipes['stdout'], cmd_pipes['stderr']
 
-    def kill(self, cmd_pipes):
-        pass
-
     @classmethod
     def machine_subfields(cls) -> List[Argument]:
         """Generate the machine subfields.

--- a/dpdispatcher/hdfs_context.py
+++ b/dpdispatcher/hdfs_context.py
@@ -247,6 +247,3 @@ class HDFSContext(BaseContext):
 
     def read_file(self, fname):
         return HDFS.read_hdfs_file(os.path.join(self.remote_root, fname))
-
-    def kill(self, job_id):
-        pass

--- a/dpdispatcher/lazy_local_context.py
+++ b/dpdispatcher/lazy_local_context.py
@@ -1,5 +1,4 @@
 import os
-import signal
 import subprocess as sp
 
 from dpdispatcher.base_context import BaseContext
@@ -166,9 +165,6 @@ class LazyLocalContext(BaseContext):
             cmd, cwd=self.local_root, shell=True, stdout=sp.PIPE, stderr=sp.PIPE
         )
         return proc
-
-    def kill(self, job_id):
-        os.kill(job_id, signal.SIGTERM)
 
     def check_finish(self, proc):
         return proc.poll() is not None

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import shutil
-import signal
 import subprocess as sp
 from glob import glob
 from subprocess import TimeoutExpired
@@ -290,9 +289,6 @@ class LocalContext(BaseContext):
             cmd, cwd=self.remote_root, shell=True, stdout=sp.PIPE, stderr=sp.PIPE
         )
         return proc
-
-    def kill(self, job_id):
-        os.kill(job_id, signal.SIGTERM)
 
     def check_finish(self, proc):
         return proc.poll() is not None

--- a/dpdispatcher/lsf.py
+++ b/dpdispatcher/lsf.py
@@ -212,5 +212,12 @@ class LSF(Machine):
         ]
 
     def kill(self, job):
+        """Kill the job.
+
+        Parameters
+        ----------
+        job : Job
+            job
+        """
         job_id = job.job_id
         ret, stdin, stdout, stderr = self.context.block_call("bkill " + str(job_id))

--- a/dpdispatcher/lsf.py
+++ b/dpdispatcher/lsf.py
@@ -210,3 +210,7 @@ class LSF(Machine):
                 doc="Extra arguments.",
             )
         ]
+
+    def kill(self, job):
+        job_id = job.job_id
+        ret, stdin, stdout, stderr = self.context.block_call("bkill " + str(job_id))

--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -443,3 +443,9 @@ class Machine(metaclass=ABCMeta):
                 "kwargs", dict, optional=True, doc="This field is empty for this batch."
             )
         ]
+
+    def kill(self, job):
+        """Kill the job.
+
+        If not implemented, pass.
+        """

--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -447,5 +447,11 @@ class Machine(metaclass=ABCMeta):
     def kill(self, job):
         """Kill the job.
 
-        If not implemented, pass.
+        If not implemented, pass and let the user manually kill it.
+
+        Parameters
+        ----------
+        job : Job
+            job
         """
+        dlog.warning("Job %s should be manually killed" % job.job_id)

--- a/dpdispatcher/pbs.py
+++ b/dpdispatcher/pbs.py
@@ -96,6 +96,13 @@ class PBS(Machine):
         return self.context.check_file_exists(job_tag_finished)
 
     def kill(self, job):
+        """Kill the job.
+
+        Parameters
+        ----------
+        job : Job
+            job
+        """
         job_id = job.job_id
         ret, stdin, stdout, stderr = self.context.block_call("qdel " + str(job_id))
 

--- a/dpdispatcher/pbs.py
+++ b/dpdispatcher/pbs.py
@@ -95,6 +95,10 @@ class PBS(Machine):
         job_tag_finished = job.job_hash + "_job_tag_finished"
         return self.context.check_file_exists(job_tag_finished)
 
+    def kill(self, job):
+        job_id = job.job_id
+        ret, stdin, stdout, stderr = self.context.block_call("qdel " + str(job_id))
+
 
 class Torque(PBS):
     def check_status(self, job):

--- a/dpdispatcher/shell.py
+++ b/dpdispatcher/shell.py
@@ -102,6 +102,13 @@ class Shell(Machine):
         return self.context.check_file_exists(job_tag_finished)
 
     def kill(self, job):
+        """Kill the job.
+
+        Parameters
+        ----------
+        job : Job
+            job
+        """
         job_id = job.job_id
         # 9 means exit, cannot be blocked
         ret, stdin, stdout, stderr = self.context.block_call("kill -9 " + str(job_id))

--- a/dpdispatcher/shell.py
+++ b/dpdispatcher/shell.py
@@ -100,3 +100,8 @@ class Shell(Machine):
         job_tag_finished = job.job_hash + "_job_tag_finished"
         # print('job finished: ',job.job_id, job_tag_finished)
         return self.context.check_file_exists(job_tag_finished)
+
+    def kill(self, job):
+        job_id = job.job_id
+        # 9 means exit, cannot be blocked
+        ret, stdin, stdout, stderr = self.context.block_call("kill -9 " + str(job_id))

--- a/dpdispatcher/slurm.py
+++ b/dpdispatcher/slurm.py
@@ -195,6 +195,14 @@ class Slurm(Machine):
             )
         ]
 
+    def kill(self, job):
+        job_id = job.job_id
+        # -Q Do not report an error if the specified job is already completed.
+        ret, stdin, stdout, stderr = self.context.block_call(
+            "scancel -Q " + str(job_id)
+        )
+        # we do not need to stop here if scancel failed; just continue
+
 
 class SlurmJobArray(Slurm):
     """Slurm with job array enabled for multiple tasks in a job."""

--- a/dpdispatcher/slurm.py
+++ b/dpdispatcher/slurm.py
@@ -196,6 +196,13 @@ class Slurm(Machine):
         ]
 
     def kill(self, job):
+        """Kill the job.
+
+        Parameters
+        ----------
+        job : Job
+            job
+        """
         job_id = job.job_id
         # -Q Do not report an error if the specified job is already completed.
         ret, stdin, stdout, stderr = self.context.block_call(

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -767,12 +767,6 @@ class SSHContext(BaseContext):
             retcode = cmd_pipes["stdout"].channel.recv_exit_status()
             return retcode, cmd_pipes["stdout"], cmd_pipes["stderr"]
 
-    def kill(self, cmd_pipes):
-        raise RuntimeError(
-            "dose not work! we do not know how to kill proc through paramiko.SSHClient"
-        )
-        # self.block_checkcall('kill -15 %s' % cmd_pipes['pid'])
-
     def _rmtree(self, remotepath, verbose=False):
         """Remove the remote path."""
         # The original implementation method removes files one by one using sftp.

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -325,10 +325,7 @@ class Submission:
         ]
         for job in removed_jobs:
             # kill unfinished jobs
-            try:
-                self.machine.context.kill(job.job_id)
-            except Exception as e:
-                dlog.info("Can not kill job %s" % job.job_id)
+            self.machine.kill(job)
 
             # remove unfinished tasks
             import os

--- a/tests/test_run_submission_ratio_unfinished.py
+++ b/tests/test_run_submission_ratio_unfinished.py
@@ -1,0 +1,145 @@
+"""Set ratio_unfinished to 1.0 to test killing jobs."""
+
+import os
+import shutil
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+__package__ = "tests"
+import unittest
+
+from .context import (
+    Machine,
+    Resources,
+    Submission,
+    Task,
+    setUpModule,  # noqa: F401
+)
+
+
+class RunSubmission:
+    def setUp(self):
+        self.machine_dict = {
+            "batch_type": "Shell",
+            "context_type": "LocalContext",
+            "local_root": "test_run_submission/",
+            # /data is mounted in the docker container
+            "remote_root": os.path.join(
+                os.environ.get("CI_SHARED_SPACE", "/"), "tmp_run_submission"
+            ),
+            "remote_profile": {},
+        }
+        self.resources_dict = {
+            "number_node": 1,
+            "cpu_per_node": 1,
+            "gpu_per_node": 0,
+            "queue_name": "?",
+            "group_size": 2,
+            "strategy": {"ratio_unfinished": 0.67},  # 2/3
+        }
+        os.makedirs(
+            os.path.join(self.machine_dict["local_root"], "test_dir"), exist_ok=True
+        )
+        os.makedirs(
+            os.path.join(self.machine_dict["local_root"], "test_dir", "test space"),
+            exist_ok=True,
+        )
+        with open(
+            os.path.join(
+                self.machine_dict["local_root"],
+                "test_dir",
+                "test space",
+                "inp space.txt",
+            ),
+            "w",
+        ) as f:
+            f.write("inp space")
+
+    def test_run_submission(self):
+        machine = Machine.load_from_dict(self.machine_dict)
+        resources = Resources.load_from_dict(self.resources_dict)
+
+        task_list = []
+        for ii in range(4):
+            task = Task(
+                command=f"echo dpdispatcher_unittest_{ii}",
+                task_work_path="./",
+                forward_files=[],
+                backward_files=[f"out{ii}.txt"],
+                outlog=f"out{ii}.txt",
+            )
+            task_list.append(task)
+
+        # test space in file name
+        task_list.append(
+            Task(
+                command="sleep 1000 && echo dpdispatcher_unittest_space",
+                task_work_path="test space/",
+                forward_files=["inp space.txt"],
+                backward_files=["out space.txt"],
+                outlog="out space.txt",
+            )
+        )
+        submission = Submission(
+            work_base="test_dir/",
+            machine=machine,
+            resources=resources,
+            forward_common_files=[],
+            backward_common_files=[],
+            task_list=task_list,
+        )
+        submission.run_submission()
+
+    def tearDown(self):
+        shutil.rmtree(os.path.join(self.machine_dict["local_root"]))
+
+
+@unittest.skipIf(
+    os.environ.get("DPDISPATCHER_TEST") != "slurm",
+    "outside the slurm testing environment",
+)
+class TestSlurmRun(RunSubmission, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.machine_dict["batch_type"] = "Slurm"
+        self.resources_dict["queue_name"] = "normal"
+
+
+@unittest.skipIf(
+    os.environ.get("DPDISPATCHER_TEST") != "slurm",
+    "outside the slurm testing environment",
+)
+class TestSlurmJobArrayRun(RunSubmission, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.machine_dict["batch_type"] = "SlurmJobArray"
+        self.resources_dict["queue_name"] = "normal"
+
+
+@unittest.skipIf(
+    os.environ.get("DPDISPATCHER_TEST") != "slurm",
+    "outside the slurm testing environment",
+)
+class TestSlurmJobArrayRun2(RunSubmission, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.machine_dict["batch_type"] = "SlurmJobArray"
+        self.resources_dict["queue_name"] = "normal"
+        self.resources_dict["kwargs"] = {"slurm_job_size": 2}
+
+
+@unittest.skipIf(
+    os.environ.get("DPDISPATCHER_TEST") != "pbs", "outside the pbs testing environment"
+)
+class TestPBSRun(RunSubmission, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.machine_dict["batch_type"] = "PBS"
+        self.resources_dict["queue_name"] = "workq"
+
+
+@unittest.skipIf(sys.platform == "win32", "Shell is not supported on Windows")
+class TestLazyLocalContext(RunSubmission, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.machine_dict["context_type"] = "LazyLocalContext"


### PR DESCRIPTION
The current job kill feature is implemented in the `Context`. This is not correct, the command to kill the job is related and only related to `Machine`. This PR reimplements this feature in the `Machine` classes.