### PR TITLE
support `ratio_unfinished` in the task level 

### DIFF
--- a/dpdispatcher/slurm.py
+++ b/dpdispatcher/slurm.py
@@ -361,11 +361,8 @@ class SlurmJobArray(Slurm):
     def check_finish_tag(self, job):
         results = []
         for task in job.job_task_list:
-            task_tag_finished = (
-                pathlib.PurePath(task.task_work_path)
-                / (task.task_hash + "_task_tag_finished")
-            ).as_posix()
-            results.append(self.context.check_file_exists(task_tag_finished))
+            task.get_task_state()
+            results.append(task.task_state == JobStatus.finished)
         return all(results)
 
     @classmethod

--- a/dpdispatcher/slurm.py
+++ b/dpdispatcher/slurm.py
@@ -361,7 +361,7 @@ class SlurmJobArray(Slurm):
     def check_finish_tag(self, job):
         results = []
         for task in job.job_task_list:
-            task.get_task_state()
+            task.get_task_state(self.context)
             results.append(task.task_state == JobStatus.finished)
         return all(results)
 

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -4,7 +4,6 @@ import json
 import os
 import pathlib
 import random
-import shutil
 import time
 import uuid
 from hashlib import sha1
@@ -345,11 +344,8 @@ class Submission:
         for task in self.belonging_tasks:
             if task.task_state == JobStatus.finished:
                 finished_tasks.append(task)
-            else:
-                shutil.rmtree(
-                    os.path.join(self.machine.context.local_root, task.task_work_path),
-                    ignore_errors=True,
-                )
+            # there is no need to remove actual remote directory
+            # as it should be cleaned anyway
         self.belonging_tasks = finished_tasks
         # clean removed tasks in jobs - although this should not be necessary
         for job in self.belonging_jobs:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -320,6 +320,7 @@ class Submission:
         bool
             whether the ratio of unfinished tasks in the submission is larger than ratio_unfinished
         """
+        assert self.resources is not None
         if self.resources.group_size == 1:
             # if group size is 1, calculate job state is enough and faster
             status_list = [job.job_state for job in self.belonging_jobs]

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -334,6 +334,7 @@ class Submission:
         return finished_num / len(self.belonging_tasks) >= (1 - ratio_unfinished)
 
     def remove_unfinished_tasks(self):
+        dlog.info("Remove unfinished tasks")
         # kill all jobs and mark them as finished
         for job in self.belonging_jobs:
             if job.job_state != JobStatus.finished:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -331,7 +331,7 @@ class Submission:
                 task.get_task_state(self.machine.context)
                 status_list.append(task.task_state)
         finished_num = status_list.count(JobStatus.finished)
-        return finished_num / len(self.belonging_jobs) >= (1 - ratio_unfinished)
+        return finished_num / len(self.belonging_tasks) >= (1 - ratio_unfinished)
 
     def remove_unfinished_tasks(self):
         # kill all jobs and mark them as finished


### PR DESCRIPTION
Currently, `ratio_unfinished` calculates the ratio of unfinished jobs. When `group_size > 1`, the ratio of unfinished tasks should be more valuable, and we don't need to drop finished tasks in unfinished jobs.