### PR TITLE
ssh: raise clear error when broken symbolic link is found

### DIFF
--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -542,14 +542,11 @@ class SSHContext(BaseContext):
                         directory_list.append(root)
                     for name in files:
                         file_list.append(os.path.join(root, name))
+            elif os.path.islink(file_name) and not os.path.exists(file_name):
+                raise OSError(f"{file_name} is broken symbolic link")
             elif glob(file_name):
                 # If the file name contains a wildcard, os.path functions will fail to identify it. Use glob to get the complete list of filenames which match the wildcard.
                 abs_file_list = glob(file_name)
-                for ff in abs_file_list:
-                    if os.path.islink(ff) and not os.path.exists(ff):
-                        raise OSError(
-                            f"{os.path.join(work_path, ff)} is broken symbolic link"
-                        )
                 rel_file_list = [
                     os.path.relpath(ii, start=work_path) for ii in abs_file_list
                 ]

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -545,6 +545,11 @@ class SSHContext(BaseContext):
             elif glob(file_name):
                 # If the file name contains a wildcard, os.path functions will fail to identify it. Use glob to get the complete list of filenames which match the wildcard.
                 abs_file_list = glob(file_name)
+                for ff in abs_file_list:
+                    if os.path.islink(ff) and not os.path.exists(ff):
+                        raise OSError(
+                            f"{os.path.join(work_path, ff)} is broken symbolic link"
+                        )
                 rel_file_list = [
                     os.path.relpath(ii, start=work_path) for ii in abs_file_list
                 ]


### PR DESCRIPTION
One currently gets a `RecursionError` when a broken symbolic link is uploaded, as it tries to walk again and again.