### PR TITLE
Update local_context.py/ssh_context.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: doc/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats: all
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: doc/requirements.txt

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -156,7 +156,7 @@ class LocalContext(BaseContext):
             for kk in ii.backward_files:
                 abs_flist_r = glob(os.path.join(remote_job, kk))
                 abs_flist_l = glob(os.path.join(local_job, kk))
-                if not abs_file_list_r and not abs_file_list_l:
+                if not abs_flist_r and not abs_flist_l:
                     raise RuntimeError(
                         "cannot find download file " + os.path.join(remote_job, kk)
                     )
@@ -215,7 +215,7 @@ class LocalContext(BaseContext):
         for kk in submission.backward_common_files:
             abs_flist_r = glob(os.path.join(remote_job, kk))
             abs_flist_l = glob(os.path.join(local_job, kk))
-            if not abs_file_list_r and not abs_file_list_l:
+            if not abs_flist_r and not abs_flist_l:
                 raise RuntimeError(
                     "cannot find download file " + os.path.join(remote_job, kk)
                 )

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -162,7 +162,7 @@ class LocalContext(BaseContext):
                             tag_file_path = os.path.join(
                                 self.local_root,
                                 ii.task_work_path,
-                                "tag_failure_download_%s" % kk
+                                "tag_failure_download_%s" % kk,
                             )
                             with open(tag_file_path, "w") as fp:
                                 pass

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -158,7 +158,9 @@ class LocalContext(BaseContext):
                 rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist]
                 flist.extend(rel_flist)
             if back_error:
-                flist += glob(os.path.join(remote_job, "error*"))
+                abs_flist = glob(os.path.join(remote_job, "error*"))
+                rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist]
+                flist.extend(rel_flist)
             for jj in flist:
                 rfile = os.path.join(remote_job, jj)
                 lfile = os.path.join(local_job, jj)
@@ -208,7 +210,9 @@ class LocalContext(BaseContext):
             rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist]
             flist.extend(rel_flist)
         if back_error:
-            flist += glob(os.path.join(remote_job, "error*"))
+            abs_flist = glob(os.path.join(remote_job, "error*"))
+            rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist]
+            flist.extend(rel_flist)
         for jj in flist:
             rfile = os.path.join(remote_job, jj)
             lfile = os.path.join(local_job, jj)

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -154,8 +154,11 @@ class LocalContext(BaseContext):
             remote_job = os.path.join(self.remote_root, ii.task_work_path)
             flist = []
             for kk in ii.backward_files:
-                abs_flist = glob(os.path.join(remote_job, kk))
-                rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist]
+                abs_flist_r = glob(os.path.join(remote_job, kk))
+                abs_flist_l = glob(os.path.join(local_job, kk))
+                if not abs_file_list_r and not abs_file_list_l:
+                    raise RuntimeError("cannot find download file " + os.path.join(remote_job, kk))
+                rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist_r]
                 flist.extend(rel_flist)
             if back_error:
                 abs_flist = glob(os.path.join(remote_job, "error*"))
@@ -206,8 +209,11 @@ class LocalContext(BaseContext):
         remote_job = self.remote_root
         flist = []
         for kk in submission.backward_common_files:
-            abs_flist = glob(os.path.join(remote_job, kk))
-            rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist]
+            abs_flist_r = glob(os.path.join(remote_job, kk))
+            abs_flist_l = glob(os.path.join(local_job, kk))
+            if not abs_file_list_r and not abs_file_list_l:
+                raise RuntimeError("cannot find download file " + os.path.join(remote_job, kk))
+            rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist_r]
             flist.extend(rel_flist)
         if back_error:
             abs_flist = glob(os.path.join(remote_job, "error*"))

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -157,8 +157,12 @@ class LocalContext(BaseContext):
                 abs_flist_r = glob(os.path.join(remote_job, kk))
                 abs_flist_l = glob(os.path.join(local_job, kk))
                 if not abs_file_list_r and not abs_file_list_l:
-                    raise RuntimeError("cannot find download file " + os.path.join(remote_job, kk))
-                rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist_r]
+                    raise RuntimeError(
+                        "cannot find download file " + os.path.join(remote_job, kk)
+                    )
+                rel_flist = [
+                    os.path.relpath(ii, start=remote_job) for ii in abs_flist_r
+                ]
                 flist.extend(rel_flist)
             if back_error:
                 abs_flist = glob(os.path.join(remote_job, "error*"))
@@ -212,7 +216,9 @@ class LocalContext(BaseContext):
             abs_flist_r = glob(os.path.join(remote_job, kk))
             abs_flist_l = glob(os.path.join(local_job, kk))
             if not abs_file_list_r and not abs_file_list_l:
-                raise RuntimeError("cannot find download file " + os.path.join(remote_job, kk))
+                raise RuntimeError(
+                    "cannot find download file " + os.path.join(remote_job, kk)
+                )
             rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist_r]
             flist.extend(rel_flist)
         if back_error:

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -157,9 +157,21 @@ class LocalContext(BaseContext):
                 abs_flist_r = glob(os.path.join(remote_job, kk))
                 abs_flist_l = glob(os.path.join(local_job, kk))
                 if not abs_flist_r and not abs_flist_l:
-                    raise RuntimeError(
-                        "cannot find download file " + os.path.join(remote_job, kk)
-                    )
+                    if check_exists:
+                        if mark_failure:
+                            tag_file_path = os.path.join(
+                                self.local_root,
+                                ii.task_work_path,
+                                "tag_failure_download_%s" % kk
+                            )
+                            with open(tag_file_path, "w") as fp:
+                                pass
+                        else:
+                            pass
+                    else:
+                        raise RuntimeError(
+                            "cannot find download file " + os.path.join(remote_job, kk)
+                        )
                 rel_flist = [
                     os.path.relpath(ii, start=remote_job) for ii in abs_flist_r
                 ]
@@ -216,9 +228,19 @@ class LocalContext(BaseContext):
             abs_flist_r = glob(os.path.join(remote_job, kk))
             abs_flist_l = glob(os.path.join(local_job, kk))
             if not abs_flist_r and not abs_flist_l:
-                raise RuntimeError(
-                    "cannot find download file " + os.path.join(remote_job, kk)
-                )
+                if check_exists:
+                    if mark_failure:
+                        tag_file_path = os.path.join(
+                            self.local_root, "tag_failure_download_%s" % kk
+                        )
+                        with open(tag_file_path, "w") as fp:
+                            pass
+                    else:
+                        pass
+                else:
+                    raise RuntimeError(
+                        "cannot find download file " + os.path.join(remote_job, kk)
+                    )
             rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist_r]
             flist.extend(rel_flist)
         if back_error:

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -155,9 +155,7 @@ class LocalContext(BaseContext):
             flist = []
             for kk in ii.backward_files:
                 abs_flist = glob(os.path.join(remote_job, kk))
-                rel_flist = [
-                    os.path.relpath(ii, start=remote_job) for ii in abs_flist
-                ]
+                rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist]
                 flist.extend(rel_flist)
             if back_error:
                 flist += glob(os.path.join(remote_job, "error*"))
@@ -207,9 +205,7 @@ class LocalContext(BaseContext):
         flist = []
         for kk in submission.backward_common_files:
             abs_flist = glob(os.path.join(remote_job, kk))
-            rel_flist = [
-                os.path.relpath(ii, start=remote_job) for ii in abs_flist
-            ]
+            rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist]
             flist.extend(rel_flist)
         if back_error:
             flist += glob(os.path.join(remote_job, "error*"))

--- a/dpdispatcher/local_context.py
+++ b/dpdispatcher/local_context.py
@@ -152,7 +152,13 @@ class LocalContext(BaseContext):
         for ii in submission.belonging_tasks:
             local_job = os.path.join(self.local_root, ii.task_work_path)
             remote_job = os.path.join(self.remote_root, ii.task_work_path)
-            flist = ii.backward_files
+            flist = []
+            for kk in ii.backward_files:
+                abs_flist = glob(os.path.join(remote_job, kk))
+                rel_flist = [
+                    os.path.relpath(ii, start=remote_job) for ii in abs_flist
+                ]
+                flist.extend(rel_flist)
             if back_error:
                 flist += glob(os.path.join(remote_job, "error*"))
             for jj in flist:
@@ -198,7 +204,13 @@ class LocalContext(BaseContext):
                     pass
         local_job = self.local_root
         remote_job = self.remote_root
-        flist = submission.backward_common_files
+        flist = []
+        for kk in submission.backward_common_files:
+            abs_flist = glob(os.path.join(remote_job, kk))
+            rel_flist = [
+                os.path.relpath(ii, start=remote_job) for ii in abs_flist
+            ]
+            flist.extend(rel_flist)
         if back_error:
             flist += glob(os.path.join(remote_job, "error*"))
         for jj in flist:

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -718,7 +718,7 @@ class SSHContext(BaseContext):
                     self.list_remote_dir(
                         self.sftp, remote_root, remote_root, remote_file_list
                     )
-                    abs_errors = fnmatch.filter(remote_file_list, jj)
+                    abs_errors = fnmatch.filter(remote_file_list, "error*")
                 rel_errors = [
                     pathlib.PurePath(os.path.join(task.task_work_path, ii)).as_posix()
                     for ii in abs_errors

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import fnmatch
 import os
 import pathlib
 import shlex
@@ -647,12 +648,13 @@ class SSHContext(BaseContext):
         file_list = []
         # for ii in job_dirs :
         for task in submission.belonging_tasks:
+            remote_file_list = self.sftp.listdir(pathlib.PurePath(
+                os.path.join(self.remote_root, task.task_work_path)).as_posix())
             for jj in task.backward_files:
-                file_name_list = glob(
-                    pathlib.PurePath(os.path.join(task.task_work_path, jj)).as_posix()
-                )
+                abs_file_list = fnmatch.filter(remote_file_list, jj)
+                rel_file_list = [pathlib.PurePath(os.path.join(task.task_work_path,ii)).as_posix() for ii in abs_file_list]
                 if check_exists:
-                    for file_name in file_name_list:
+                    for file_name in rel_file_list:
                         if self.check_file_exists(file_name):
                             file_list.append(file_name)
                         elif mark_failure:
@@ -668,10 +670,11 @@ class SSHContext(BaseContext):
                         else:
                             pass
                 else:
-                    file_list.extend(file_name_list)
+                    file_list.extend(rel_file_list)
             if back_error:
-                errors = glob(os.path.join(task.task_work_path, "error*"))
-                file_list.extend(errors)
+                abs_errors = fnmatch.filter(remote_file_list,"error*")
+                rel_errors = [pathlib.PurePath(os.path.join(task.task_work_path,ii)).as_posix() for ii in abs_errors]
+                file_list.extend(rel_errors)
         file_list.extend(submission.backward_common_files)
         if len(file_list) > 0:
             self._get_files(

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -416,7 +416,7 @@ class SSHContext(BaseContext):
         assert os.path.isabs(remote_root), "remote_root must be a abspath"
         self.temp_remote_root = remote_root
         self.remote_profile = remote_profile
-        self.remote_root = None
+        self.remote_root = ""
 
         # self.job_uuid = None
         self.clean_asynchronously = clean_asynchronously
@@ -668,11 +668,11 @@ class SSHContext(BaseContext):
                         abs_file_list = fnmatch.filter(remote_file_list, jj)
                     else:
                         remote_file_list = []
-                        remote_root = pathlib.PurePath(
+                        remote_job = pathlib.PurePath(
                             os.path.join(self.remote_root, ii.task_work_path)
                         ).as_posix()
                         self.list_remote_dir(
-                            self.sftp, remote_root, remote_root, remote_file_list
+                            self.sftp, remote_job, remote_job, remote_file_list
                         )
 
                         abs_file_list = fnmatch.filter(remote_file_list, jj)
@@ -708,11 +708,11 @@ class SSHContext(BaseContext):
                     abs_errors = fnmatch.filter(remote_file_list, "error*")
                 else:
                     remote_file_list = []
-                    remote_root = pathlib.PurePath(
+                    remote_job = pathlib.PurePath(
                         os.path.join(self.remote_root, ii.task_work_path)
                     ).as_posix()
                     self.list_remote_dir(
-                        self.sftp, remote_root, remote_root, remote_file_list
+                        self.sftp, remote_job, remote_job, remote_file_list
                     )
                     abs_errors = fnmatch.filter(remote_file_list, "error*")
                 rel_errors = [

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -648,11 +648,14 @@ class SSHContext(BaseContext):
         file_list = []
         # for ii in job_dirs :
         for task in submission.belonging_tasks:
-            remote_file_list = self.sftp.listdir(
-                pathlib.PurePath(
-                    os.path.join(self.remote_root, task.task_work_path)
-                ).as_posix()
-            )
+            try:
+                remote_file_list = self.sftp.listdir(
+                    pathlib.PurePath(
+                        os.path.join(self.remote_root, task.task_work_path)
+                    ).as_posix()
+                )
+            except TypeError:
+                raise TypeError("The path may be wrong.")
             for jj in task.backward_files:
                 abs_file_list = fnmatch.filter(remote_file_list, jj)
                 rel_file_list = [

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -648,11 +648,17 @@ class SSHContext(BaseContext):
         file_list = []
         # for ii in job_dirs :
         for task in submission.belonging_tasks:
-            remote_file_list = self.sftp.listdir(pathlib.PurePath(
-                os.path.join(self.remote_root, task.task_work_path)).as_posix())
+            remote_file_list = self.sftp.listdir(
+                pathlib.PurePath(
+                    os.path.join(self.remote_root, task.task_work_path)
+                ).as_posix()
+            )
             for jj in task.backward_files:
                 abs_file_list = fnmatch.filter(remote_file_list, jj)
-                rel_file_list = [pathlib.PurePath(os.path.join(task.task_work_path,ii)).as_posix() for ii in abs_file_list]
+                rel_file_list = [
+                    pathlib.PurePath(os.path.join(task.task_work_path, ii)).as_posix()
+                    for ii in abs_file_list
+                ]
                 if check_exists:
                     for file_name in rel_file_list:
                         if self.check_file_exists(file_name):
@@ -672,8 +678,11 @@ class SSHContext(BaseContext):
                 else:
                     file_list.extend(rel_file_list)
             if back_error:
-                abs_errors = fnmatch.filter(remote_file_list,"error*")
-                rel_errors = [pathlib.PurePath(os.path.join(task.task_work_path,ii)).as_posix() for ii in abs_errors]
+                abs_errors = fnmatch.filter(remote_file_list, "error*")
+                rel_errors = [
+                    pathlib.PurePath(os.path.join(task.task_work_path, ii)).as_posix()
+                    for ii in abs_errors
+                ]
                 file_list.extend(rel_errors)
         file_list.extend(submission.backward_common_files)
         if len(file_list) > 0:

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -677,17 +677,13 @@ class SSHContext(BaseContext):
 
                         abs_file_list = fnmatch.filter(remote_file_list, jj)
                     rel_file_list = [
-                        pathlib.PurePath(
-                            os.path.join(ii.task_work_path, kk)
-                        ).as_posix()
+                        pathlib.PurePath(os.path.join(ii.task_work_path, kk)).as_posix()
                         for kk in abs_file_list
                     ]
 
                 else:
                     rel_file_list = [
-                        pathlib.PurePath(
-                            os.path.join(ii.task_work_path, jj)
-                        ).as_posix()
+                        pathlib.PurePath(os.path.join(ii.task_work_path, jj)).as_posix()
                     ]
                 if check_exists:
                     for file_name in rel_file_list:

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -635,20 +635,19 @@ class SSHContext(BaseContext):
             directories=directory_list,
             tar_compress=self.remote_profile.get("tar_compress", None),
         )
-    def list_remote_dir(self,
-                    sftp,
-                    remote_dir,
-                    ref_remote_root,
-                    result_list):
+
+    def list_remote_dir(self, sftp, remote_dir, ref_remote_root, result_list):
         for entry in sftp.listdir_attr(remote_dir):
-            remote_name = pathlib.PurePath(os.path.join(remote_dir,entry.filename)).as_posix()
+            remote_name = pathlib.PurePath(
+                os.path.join(remote_dir, entry.filename)
+            ).as_posix()
             st_mode = entry.st_mode
             if S_ISDIR(st_mode):
                 self.list_remote_dir(sftp, remote_name, ref_remote_root, result_list)
             elif S_ISREG(st_mode):
                 rel_remote_name = os.path.relpath(remote_name, start=ref_remote_root)
                 result_list.append(rel_remote_name)
-                
+
     def download(
         self,
         submission,
@@ -669,17 +668,27 @@ class SSHContext(BaseContext):
                         abs_file_list = fnmatch.filter(remote_file_list, jj)
                     else:
                         remote_file_list = []
-                        remote_root = pathlib.PurePath(os.path.join(self.remote_root, task.task_work_path)).as_posix()
-                        self.list_remote_dir(self.sftp,
-                                remote_root,
-                                remote_root,
-                                remote_file_list)
+                        remote_root = pathlib.PurePath(
+                            os.path.join(self.remote_root, task.task_work_path)
+                        ).as_posix()
+                        self.list_remote_dir(
+                            self.sftp, remote_root, remote_root, remote_file_list
+                        )
 
                         abs_file_list = fnmatch.filter(remote_file_list, jj)
-                    rel_file_list = [pathlib.PurePath(os.path.join(task.task_work_path,ii)).as_posix() for ii in abs_file_list]
+                    rel_file_list = [
+                        pathlib.PurePath(
+                            os.path.join(task.task_work_path, ii)
+                        ).as_posix()
+                        for ii in abs_file_list
+                    ]
 
                 else:
-                    rel_file_list = [pathlib.PurePath(os.path.join(task.task_work_path,jj)).as_posix()]
+                    rel_file_list = [
+                        pathlib.PurePath(
+                            os.path.join(task.task_work_path, jj)
+                        ).as_posix()
+                    ]
                 if check_exists:
                     for file_name in rel_file_list:
                         if self.check_file_exists(file_name):
@@ -703,13 +712,17 @@ class SSHContext(BaseContext):
                     abs_errors = fnmatch.filter(remote_file_list, "error*")
                 else:
                     remote_file_list = []
-                    remote_root = pathlib.PurePath(os.path.join(self.remote_root, task.task_work_path)).as_posix()
-                    self.list_remote_dir(self.sftp,
-                            remote_root,
-                            remote_root,
-                            remote_file_list)
+                    remote_root = pathlib.PurePath(
+                        os.path.join(self.remote_root, task.task_work_path)
+                    ).as_posix()
+                    self.list_remote_dir(
+                        self.sftp, remote_root, remote_root, remote_file_list
+                    )
                     abs_errors = fnmatch.filter(remote_file_list, jj)
-                rel_errors = [pathlib.PurePath(os.path.join(task.task_work_path,ii)).as_posix() for ii in abs_errors]
+                rel_errors = [
+                    pathlib.PurePath(os.path.join(task.task_work_path, ii)).as_posix()
+                    for ii in abs_errors
+                ]
                 file_list.extend(rel_errors)
         file_list.extend(submission.backward_common_files)
         if len(file_list) > 0:

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -648,9 +648,9 @@ class SSHContext(BaseContext):
         # for ii in job_dirs :
         for task in submission.belonging_tasks:
             for jj in task.backward_files:
-                file_name_list = glob(pathlib.PurePath(
-                    os.path.join(task.task_work_path, jj)
-                ).as_posix())
+                file_name_list = glob(
+                    pathlib.PurePath(os.path.join(task.task_work_path, jj)).as_posix()
+                )
                 if check_exists:
                     for file_name in file_name_list:
                         if self.check_file_exists(file_name):

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -660,16 +660,16 @@ class SSHContext(BaseContext):
         self.ssh_session.ensure_alive()
         file_list = []
         # for ii in job_dirs :
-        for task in submission.belonging_tasks:
+        for ii in submission.belonging_tasks:
             remote_file_list = None
-            for jj in task.backward_files:
+            for jj in ii.backward_files:
                 if "*" in jj or "?" in jj:
                     if remote_file_list is not None:
                         abs_file_list = fnmatch.filter(remote_file_list, jj)
                     else:
                         remote_file_list = []
                         remote_root = pathlib.PurePath(
-                            os.path.join(self.remote_root, task.task_work_path)
+                            os.path.join(self.remote_root, ii.task_work_path)
                         ).as_posix()
                         self.list_remote_dir(
                             self.sftp, remote_root, remote_root, remote_file_list
@@ -678,15 +678,15 @@ class SSHContext(BaseContext):
                         abs_file_list = fnmatch.filter(remote_file_list, jj)
                     rel_file_list = [
                         pathlib.PurePath(
-                            os.path.join(task.task_work_path, ii)
+                            os.path.join(ii.task_work_path, kk)
                         ).as_posix()
-                        for ii in abs_file_list
+                        for kk in abs_file_list
                     ]
 
                 else:
                     rel_file_list = [
                         pathlib.PurePath(
-                            os.path.join(task.task_work_path, jj)
+                            os.path.join(ii.task_work_path, jj)
                         ).as_posix()
                     ]
                 if check_exists:
@@ -697,7 +697,7 @@ class SSHContext(BaseContext):
                             with open(
                                 os.path.join(
                                     self.local_root,
-                                    task.task_work_path,
+                                    ii.task_work_path,
                                     "tag_failure_download_%s" % jj,
                                 ),
                                 "w",
@@ -713,15 +713,15 @@ class SSHContext(BaseContext):
                 else:
                     remote_file_list = []
                     remote_root = pathlib.PurePath(
-                        os.path.join(self.remote_root, task.task_work_path)
+                        os.path.join(self.remote_root, ii.task_work_path)
                     ).as_posix()
                     self.list_remote_dir(
                         self.sftp, remote_root, remote_root, remote_file_list
                     )
                     abs_errors = fnmatch.filter(remote_file_list, "error*")
                 rel_errors = [
-                    pathlib.PurePath(os.path.join(task.task_work_path, ii)).as_posix()
-                    for ii in abs_errors
+                    pathlib.PurePath(os.path.join(ii.task_work_path, kk)).as_posix()
+                    for kk in abs_errors
                 ]
                 file_list.extend(rel_errors)
         file_list.extend(submission.backward_common_files)

--- a/tests/sample_class.py
+++ b/tests/sample_class.py
@@ -83,7 +83,7 @@ class SampleClass:
         return task_dict
 
     @classmethod
-    def get_sample_task_list(cls):
+    def get_sample_task_list(cls, backward_wildcard=False):
         task1 = Task(
             command="lmp -i input.lammps",
             task_work_path="bct-1/",
@@ -109,6 +109,16 @@ class SampleClass:
             backward_files=["log.lammps"],
         )
         task_list = [task1, task2, task3, task4]
+        if backward_wildcard:
+            task_wildcard = Task(
+                command="lmp -i input.lammps",
+                task_work_path="bct-backward_wildcard/",
+                forward_files=[],
+                backward_files=["test*/test*"],
+                outlog="wildcard.log",
+                errlog="wildcard.err",
+            )
+            task_list.append(task_wildcard)
         return task_list
 
     @classmethod
@@ -127,9 +137,9 @@ class SampleClass:
         return empty_submission
 
     @classmethod
-    def get_sample_submission(cls):
+    def get_sample_submission(cls, backward_wildcard=False):
         submission = cls.get_sample_empty_submission()
-        task_list = cls.get_sample_task_list()
+        task_list = cls.get_sample_task_list(backward_wildcard=backward_wildcard)
         submission.register_task_list(task_list)
         submission.generate_jobs()
         return submission

--- a/tests/test_ssh_context.py
+++ b/tests/test_ssh_context.py
@@ -50,6 +50,7 @@ class TestSSHContext(unittest.TestCase):
             "bct-3/log.lammps",
             "bct-4/log.lammps",
             "dir with space/file with space",
+            "bct-backward_wildcard/test456",
             "bct-backward_wildcard/test123/test123",
         ]
         for file in file_list:
@@ -197,7 +198,8 @@ class TestSSHContextNoCompress(unittest.TestCase):
             "bct-3/log.lammps",
             "bct-4/log.lammps",
             "dir with space/file with space",
-            "bct-1/test123/test123",
+            "bct-backward_wildcard/test456",
+            "bct-backward_wildcard/test123/test123",
         ]
         for file in file_list:
             cls.machine.context.sftp.mkdir(

--- a/tests/test_ssh_context.py
+++ b/tests/test_ssh_context.py
@@ -41,7 +41,7 @@ class TestSSHContext(unittest.TestCase):
             cls.machine = Machine.load_from_dict(mdata)
         except (SSHException, socket.timeout):
             raise unittest.SkipTest("SSHException ssh cannot connect")
-        cls.submission = SampleClass.get_sample_submission()
+        cls.submission = SampleClass.get_sample_submission(get_sample_submission=True)
         cls.submission.bind_machine(cls.machine)
         cls.submission_hash = cls.submission.submission_hash
         file_list = [
@@ -50,6 +50,7 @@ class TestSSHContext(unittest.TestCase):
             "bct-3/log.lammps",
             "bct-4/log.lammps",
             "dir with space/file with space",
+            "bct-backward_wildcard/test123/test123",
         ]
         for file in file_list:
             cls.machine.context.sftp.mkdir(
@@ -187,7 +188,7 @@ class TestSSHContextNoCompress(unittest.TestCase):
             cls.machine = Machine.load_from_dict(mdata)
         except (SSHException, socket.timeout):
             raise unittest.SkipTest("SSHException ssh cannot connect")
-        cls.submission = SampleClass.get_sample_submission()
+        cls.submission = SampleClass.get_sample_submission(get_sample_submission=True)
         cls.submission.bind_machine(cls.machine)
         cls.submission_hash = cls.submission.submission_hash
         file_list = [
@@ -196,6 +197,7 @@ class TestSSHContextNoCompress(unittest.TestCase):
             "bct-3/log.lammps",
             "bct-4/log.lammps",
             "dir with space/file with space",
+            "bct-1/test123/test123",
         ]
         for file in file_list:
             cls.machine.context.sftp.mkdir(

--- a/tests/test_ssh_context.py
+++ b/tests/test_ssh_context.py
@@ -41,7 +41,7 @@ class TestSSHContext(unittest.TestCase):
             cls.machine = Machine.load_from_dict(mdata)
         except (SSHException, socket.timeout):
             raise unittest.SkipTest("SSHException ssh cannot connect")
-        cls.submission = SampleClass.get_sample_submission(get_sample_submission=True)
+        cls.submission = SampleClass.get_sample_submission(backward_wildcard=True)
         cls.submission.bind_machine(cls.machine)
         cls.submission_hash = cls.submission.submission_hash
         file_list = [
@@ -188,7 +188,7 @@ class TestSSHContextNoCompress(unittest.TestCase):
             cls.machine = Machine.load_from_dict(mdata)
         except (SSHException, socket.timeout):
             raise unittest.SkipTest("SSHException ssh cannot connect")
-        cls.submission = SampleClass.get_sample_submission(get_sample_submission=True)
+        cls.submission = SampleClass.get_sample_submission(backward_wildcard=True)
         cls.submission.bind_machine(cls.machine)
         cls.submission_hash = cls.submission.submission_hash
         file_list = [


### PR DESCRIPTION
To support wildcards for backward_files and backward_common_files.
Now only support for local_context and ssh_context.
#371 