### PR TITLE
throw errors if key_filename is not found

### DIFF
--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -168,6 +168,8 @@ class SSHSession:
                         pass
                     if key is not None:
                         break
+            else:
+                raise OSError(f"{{key_path} not found!")
         elif self.look_for_keys:
             for keytype, name in [
                 (paramiko.RSAKey, "rsa"),

--- a/dpdispatcher/ssh_context.py
+++ b/dpdispatcher/ssh_context.py
@@ -169,7 +169,7 @@ class SSHSession:
                     if key is not None:
                         break
             else:
-                raise OSError(f"{{key_path} not found!")
+                raise OSError(f"{key_path} not found!")
         elif self.look_for_keys:
             for keytype, name in [
                 (paramiko.RSAKey, "rsa"),


### PR DESCRIPTION
When user provides key_filename and it does not exist, it's expected to throw an error.