### PR TITLE
raise FileNotFoundError in several contexts

### DIFF
--- a/dpdispatcher/contexts/hdfs_context.py
+++ b/dpdispatcher/contexts/hdfs_context.py
@@ -88,7 +88,7 @@ class HDFSContext(BaseContext):
             for ff in task.forward_files:
                 abs_file_list = glob(os.path.join(local_job, ff))
                 if not abs_file_list:
-                    raise RuntimeError(
+                    raise FileNotFoundError(
                         "cannot find upload file " + os.path.join(local_job, ff)
                     )
                 rel_file_list = [
@@ -100,7 +100,7 @@ class HDFSContext(BaseContext):
         for fc in submission.forward_common_files:
             abs_file_list = glob(os.path.join(local_job, fc))
             if not abs_file_list:
-                raise RuntimeError(
+                raise FileNotFoundError(
                     "cannot find upload file " + os.path.join(local_job, fc)
                 )
             rel_file_list = [
@@ -170,9 +170,9 @@ class HDFSContext(BaseContext):
                             ) as fp:
                                 pass
                         else:
-                            raise RuntimeError("do not find download file " + rfile)
+                            raise FileNotFoundError("do not find download file " + rfile)
                     else:
-                        raise RuntimeError("do not find download file " + rfile)
+                        raise FileNotFoundError("do not find download file " + rfile)
                 else:
                     if os.path.exists(lfile):
                         dlog.info(f"find existing {lfile}, replacing by {rfile}")
@@ -203,9 +203,9 @@ class HDFSContext(BaseContext):
                         ) as fp:
                             pass
                     else:
-                        raise RuntimeError("do not find download file " + rfile)
+                        raise FileNotFoundError("do not find download file " + rfile)
                 else:
-                    raise RuntimeError("do not find download file " + rfile)
+                    raise FileNotFoundError("do not find download file " + rfile)
             else:
                 if os.path.exists(lfile):
                     dlog.info(f"find existing {lfile}, replacing by {rfile}")

--- a/dpdispatcher/contexts/hdfs_context.py
+++ b/dpdispatcher/contexts/hdfs_context.py
@@ -170,7 +170,9 @@ class HDFSContext(BaseContext):
                             ) as fp:
                                 pass
                         else:
-                            raise FileNotFoundError("do not find download file " + rfile)
+                            raise FileNotFoundError(
+                                "do not find download file " + rfile
+                            )
                     else:
                         raise FileNotFoundError("do not find download file " + rfile)
                 else:

--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -94,7 +94,7 @@ class LocalContext(BaseContext):
             for kk in ii.forward_files:
                 abs_file_list = glob(os.path.join(local_job, kk))
                 if not abs_file_list:
-                    raise RuntimeError(
+                    raise FileNotFoundError(
                         "cannot find upload file " + os.path.join(local_job, kk)
                     )
                 rel_file_list = [
@@ -104,7 +104,7 @@ class LocalContext(BaseContext):
 
             for jj in file_list:
                 if not os.path.exists(os.path.join(local_job, jj)):
-                    raise RuntimeError(
+                    raise FileNotFoundError(
                         "cannot find upload file " + os.path.join(local_job, jj)
                     )
                 if os.path.exists(os.path.join(remote_job, jj)):
@@ -119,7 +119,7 @@ class LocalContext(BaseContext):
         for kk in submission.forward_common_files:
             abs_file_list = glob(os.path.join(local_job, kk))
             if not abs_file_list:
-                raise RuntimeError(
+                raise FileNotFoundError(
                     "cannot find upload file " + os.path.join(local_job, kk)
                 )
             rel_file_list = [
@@ -129,7 +129,7 @@ class LocalContext(BaseContext):
 
         for jj in file_list:
             if not os.path.exists(os.path.join(local_job, jj)):
-                raise RuntimeError(
+                raise FileNotFoundError(
                     "cannot find upload file " + os.path.join(local_job, jj)
                 )
             if os.path.exists(os.path.join(remote_job, jj)):
@@ -160,7 +160,7 @@ class LocalContext(BaseContext):
                         else:
                             pass
                     else:
-                        raise RuntimeError(
+                        raise FileNotFoundError(
                             "cannot find download file " + os.path.join(remote_job, kk)
                         )
                 rel_flist = [
@@ -188,7 +188,7 @@ class LocalContext(BaseContext):
                             else:
                                 pass
                         else:
-                            raise RuntimeError("do not find download file " + rfile)
+                            raise FileNotFoundError("do not find download file " + rfile)
                     elif (not os.path.exists(rfile)) and (os.path.exists(lfile)):
                         # already downloaded
                         pass
@@ -229,7 +229,7 @@ class LocalContext(BaseContext):
                     else:
                         pass
                 else:
-                    raise RuntimeError(
+                    raise FileNotFoundError(
                         "cannot find download file " + os.path.join(remote_job, kk)
                     )
             rel_flist = [os.path.relpath(ii, start=remote_job) for ii in abs_flist_r]
@@ -255,7 +255,7 @@ class LocalContext(BaseContext):
                         else:
                             pass
                     else:
-                        raise RuntimeError("do not find download file " + rfile)
+                        raise FileNotFoundError("do not find download file " + rfile)
                 elif (not os.path.exists(rfile)) and (os.path.exists(lfile)):
                     # already downloaded
                     pass

--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -188,7 +188,9 @@ class LocalContext(BaseContext):
                             else:
                                 pass
                         else:
-                            raise FileNotFoundError("do not find download file " + rfile)
+                            raise FileNotFoundError(
+                                "do not find download file " + rfile
+                            )
                     elif (not os.path.exists(rfile)) and (os.path.exists(lfile)):
                         # already downloaded
                         pass

--- a/dpdispatcher/contexts/ssh_context.py
+++ b/dpdispatcher/contexts/ssh_context.py
@@ -569,7 +569,7 @@ class SSHContext(BaseContext):
                     rel_file_list, work_path, file_list, directory_list
                 )
             else:
-                raise RuntimeError(f"cannot find upload file {work_path} {jj}")
+                raise FileNotFoundError(f"cannot find upload file {work_path} {jj}")
 
     def upload(
         self,

--- a/tests/test_local_context.py
+++ b/tests/test_local_context.py
@@ -69,7 +69,7 @@ class TestLocalContext(unittest.TestCase):
 
         self.local_context.bind_submission(submission)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(FileNotFoundError):
             self.local_context.upload(submission)
 
     def test_upload(self):
@@ -236,7 +236,7 @@ class TestLocalContextDownload(unittest.TestCase):
             submission_hash="0_md/",
         )
         self.local_context.bind_submission(submission)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(FileNotFoundError):
             self.local_context.download(submission, check_exists=False)
 
     def test_download_mark_failure_tag(self):


### PR DESCRIPTION
#409 avoids retry in loop when the file is not found in the ssh context. But it is not apply to other contexts, and the tests hang in https://github.com/deepmodeling/dpgen/pull/1406 due to retry.