### PR TITLE
ci(test): fix py37 on macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,12 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        exclude:  # Apple Silicon ARM64 does not support Python < v3.8
+          - python-version: "3.7"
+            platform: macos-latest
+        include:  # So run those legacy versions on Intel CPUs
+          - python-version: "3.7"
+            platform: macos-13
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
xref: https://github.com/actions/runner-images/issues/9770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated testing configurations to exclude Python version 3.7 on the latest macOS for Apple Silicon ARM64 and include it on macOS 13 for Intel CPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->