### PR TITLE
fix: give detailed error message when ps is not installed

### DIFF
--- a/dpdispatcher/machines/shell.py
+++ b/dpdispatcher/machines/shell.py
@@ -77,7 +77,8 @@ class Shell(Machine):
             return JobStatus.unsubmitted
 
         if self._has_ps is None:
-            ret, stdin, stdout, stderr = self.context.block_call("which ps")
+            # avoid which; see https://stackoverflow.com/a/677212/9567349
+            ret, stdin, stdout, stderr = self.context.block_call("command -v ps")
             if ret != 0:
                 err_str = stderr.read().decode("utf-8")
                 raise RuntimeError(

--- a/dpdispatcher/machines/shell.py
+++ b/dpdispatcher/machines/shell.py
@@ -74,7 +74,7 @@ class Shell(Machine):
 
         # mark defunct process as terminated
         ret, stdin, stdout, stderr = self.context.block_call(
-            'command -v ps >/dev/null 2>&1 || { echo >&2 "I require ps but it's not installed. Aborting."; exit 1; };'
+            r"""command -v ps >/dev/null 2>&1 || { echo >&2 "I require ps but it's not installed. Aborting."; exit 1; };"""
             f"if ps -p {job_id} > /dev/null && ! (ps -o command -p {job_id} | grep defunct >/dev/null) ; then echo 1; fi"
         )
         if ret != 0:

--- a/dpdispatcher/machines/shell.py
+++ b/dpdispatcher/machines/shell.py
@@ -11,6 +11,10 @@ shell_script_header_template = """
 
 
 class Shell(Machine):
+    def bind_context(self, context):
+        super().bind_context(context)
+        self._has_ps = None
+
     def gen_script(self, job):
         shell_script = super().gen_script(job)
         return shell_script
@@ -72,6 +76,15 @@ class Shell(Machine):
         if job_id == "":
             return JobStatus.unsubmitted
 
+        if self._has_ps is None:
+            ret, stdin, stdout, stderr = self.context.block_call("which ps")
+            if ret != 0:
+                err_str = stderr.read().decode("utf-8")
+                raise RuntimeError(
+                    "ps command is not found. Consider installing it using `apt-get install procps` or `yum install procps`\nerror message:%s\nreturn code %d\n"
+                    % (err_str, ret)
+                )
+            self._has_ps = True
         # mark defunct process as terminated
         ret, stdin, stdout, stderr = self.context.block_call(
             f"if ps -p {job_id} > /dev/null && ! (ps -o command -p {job_id} | grep defunct >/dev/null) ; then echo 1; fi"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a command-line check to ensure the availability of the `ps` command before executing the main logic of the status check, enhancing system stability and preventing runtime errors.  
- **Bug Fixes**
	- Improved error handling by outputting a descriptive message when the `ps` command is not found, allowing users to understand the issue clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->