### PR TITLE
chore: make block_call as abstractmethod; merge block_checkcall

### DIFF
--- a/dpdispatcher/base_context.py
+++ b/dpdispatcher/base_context.py
@@ -82,7 +82,7 @@ class BaseContext(metaclass=ABCMeta):
             The command to run.
         asynchronously : bool, optional, default=False
             Run command asynchronously. If True, `nohup` will be used to run the command.
-    
+
         Returns
         -------
         stdin
@@ -120,7 +120,7 @@ class BaseContext(metaclass=ABCMeta):
         ----------
         cmd : str
             The command to run.
-    
+
         Returns
         -------
         exit_status
@@ -133,7 +133,6 @@ class BaseContext(metaclass=ABCMeta):
             standard error
         """
         return exit_status, stdin, stdout, stderr
-        
 
     @classmethod
     def machine_arginfo(cls) -> Argument:

--- a/dpdispatcher/base_context.py
+++ b/dpdispatcher/base_context.py
@@ -132,7 +132,6 @@ class BaseContext(metaclass=ABCMeta):
         stderr
             standard error
         """
-        return exit_status, stdin, stdout, stderr
 
     @classmethod
     def machine_arginfo(cls) -> Argument:

--- a/dpdispatcher/base_context.py
+++ b/dpdispatcher/base_context.py
@@ -73,6 +73,68 @@ class BaseContext(metaclass=ABCMeta):
     def check_finish(self, proc):
         raise NotImplementedError("abstract method")
 
+    def block_checkcall(self, cmd, asynchronously=False):
+        """Run command with arguments. Wait for command to complete.
+
+        Parameters
+        ----------
+        cmd : str
+            The command to run.
+        asynchronously : bool, optional, default=False
+            Run command asynchronously. If True, `nohup` will be used to run the command.
+    
+        Returns
+        -------
+        stdin
+            standard inout
+        stdout
+            standard output
+        stderr
+            standard error
+
+        Raises
+        ------
+        RuntimeError
+            when the return code is not zero
+        """
+        if asynchronously:
+            cmd = f"nohup {cmd} >/dev/null &"
+        exit_status, stdin, stdout, stderr = self.block_call(cmd)
+        if exit_status != 0:
+            raise RuntimeError(
+                "Get error code %d in calling %s with job: %s . message: %s"
+                % (
+                    exit_status,
+                    cmd,
+                    self.submission.submission_hash,
+                    stderr.read().decode("utf-8"),
+                )
+            )
+        return stdin, stdout, stderr
+
+    @abstractmethod
+    def block_call(self, cmd):
+        """Run command with arguments. Wait for command to complete.
+
+        Parameters
+        ----------
+        cmd : str
+            The command to run.
+    
+        Returns
+        -------
+        exit_status
+            exit code
+        stdin
+            standard inout
+        stdout
+            standard output
+        stderr
+            standard error
+        """
+        return exit_status, stdin, stdout, stderr
+        
+
     @classmethod
     def machine_arginfo(cls) -> Argument:
         """Generate the machine arginfo.

--- a/dpdispatcher/base_context.py
+++ b/dpdispatcher/base_context.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 from dargs import Argument
 
@@ -73,7 +73,7 @@ class BaseContext(metaclass=ABCMeta):
     def check_finish(self, proc):
         raise NotImplementedError("abstract method")
 
-    def block_checkcall(self, cmd, asynchronously=False):
+    def block_checkcall(self, cmd, asynchronously=False) -> Tuple[Any, Any, Any]:
         """Run command with arguments. Wait for command to complete.
 
         Parameters
@@ -113,7 +113,7 @@ class BaseContext(metaclass=ABCMeta):
         return stdin, stdout, stderr
 
     @abstractmethod
-    def block_call(self, cmd):
+    def block_call(self, cmd) -> Tuple[int, Any, Any, Any]:
         """Run command with arguments. Wait for command to complete.
 
         Parameters

--- a/dpdispatcher/contexts/dp_cloud_server_context.py
+++ b/dpdispatcher/contexts/dp_cloud_server_context.py
@@ -335,6 +335,9 @@ class BohriumContext(BaseContext):
             )
         ]
 
+    def block_call(self, cmd):
+        raise RuntimeError("Unsupported method. You may use an unsupported combination of the machine and the context.")
+
 
 DpCloudServerContext = BohriumContext
 LebesgueContext = BohriumContext

--- a/dpdispatcher/contexts/dp_cloud_server_context.py
+++ b/dpdispatcher/contexts/dp_cloud_server_context.py
@@ -336,7 +336,9 @@ class BohriumContext(BaseContext):
         ]
 
     def block_call(self, cmd):
-        raise RuntimeError("Unsupported method. You may use an unsupported combination of the machine and the context.")
+        raise RuntimeError(
+            "Unsupported method. You may use an unsupported combination of the machine and the context."
+        )
 
 
 DpCloudServerContext = BohriumContext

--- a/dpdispatcher/contexts/hdfs_context.py
+++ b/dpdispatcher/contexts/hdfs_context.py
@@ -244,3 +244,6 @@ class HDFSContext(BaseContext):
 
     def read_file(self, fname):
         return HDFS.read_hdfs_file(os.path.join(self.remote_root, fname))
+
+    def block_call(self, cmd):
+        raise RuntimeError("Unsupported method. You may use an unsupported combination of the machine and the context.")

--- a/dpdispatcher/contexts/hdfs_context.py
+++ b/dpdispatcher/contexts/hdfs_context.py
@@ -246,4 +246,6 @@ class HDFSContext(BaseContext):
         return HDFS.read_hdfs_file(os.path.join(self.remote_root, fname))
 
     def block_call(self, cmd):
-        raise RuntimeError("Unsupported method. You may use an unsupported combination of the machine and the context.")
+        raise RuntimeError(
+            "Unsupported method. You may use an unsupported combination of the machine and the context."
+        )

--- a/dpdispatcher/contexts/lazy_local_context.py
+++ b/dpdispatcher/contexts/lazy_local_context.py
@@ -112,23 +112,6 @@ class LazyLocalContext(BaseContext):
     #                else:
     #                    raise RuntimeError('do not find download file ' + fname)
 
-    def block_checkcall(self, cmd):
-        # script_dir = os.path.join(self.local_root, self.submission.work_base)
-        # os.chdir(script_dir)
-        proc = sp.Popen(
-            cmd, cwd=self.local_root, shell=True, stdout=sp.PIPE, stderr=sp.PIPE
-        )
-        o, e = proc.communicate()
-        stdout = SPRetObj(o)
-        stderr = SPRetObj(e)
-        code = proc.returncode
-        if code != 0:
-            raise RuntimeError(
-                "Get error code %d in locally calling %s with job: %s ",
-                (code, cmd, self.submission.submission_hash),
-            )
-        return None, stdout, stderr
-
     def block_call(self, cmd):
         proc = sp.Popen(
             cmd, cwd=self.local_root, shell=True, stdout=sp.PIPE, stderr=sp.PIPE

--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -288,21 +288,6 @@ class LocalContext(BaseContext):
                 # no nothing in the case of linked files
                 pass
 
-    def block_checkcall(self, cmd):
-        proc = sp.Popen(
-            cmd, cwd=self.remote_root, shell=True, stdout=sp.PIPE, stderr=sp.PIPE
-        )
-        o, e = proc.communicate()
-        stdout = SPRetObj(o)
-        stderr = SPRetObj(e)
-        code = proc.returncode
-        if code != 0:
-            raise RuntimeError(
-                f"Get error code {code} in locally calling {cmd} with job: {self.submission.submission_hash}"
-                f"\nStandard error: {stderr}"
-            )
-        return None, stdout, stderr
-
     def block_call(self, cmd):
         proc = sp.Popen(
             cmd, cwd=self.remote_root, shell=True, stdout=sp.PIPE, stderr=sp.PIPE

--- a/dpdispatcher/contexts/openapi_context.py
+++ b/dpdispatcher/contexts/openapi_context.py
@@ -258,3 +258,6 @@ class OpenAPIContext(BaseContext):
             dir_to_be_removed = os.path.join(local_root, "backup")
             if os.path.exists(dir_to_be_removed):
                 shutil.rmtree(dir_to_be_removed)
+
+    def block_call(self, cmd):
+        raise RuntimeError("Unsupported method. You may use an unsupported combination of the machine and the context.")

--- a/dpdispatcher/contexts/openapi_context.py
+++ b/dpdispatcher/contexts/openapi_context.py
@@ -260,4 +260,6 @@ class OpenAPIContext(BaseContext):
                 shutil.rmtree(dir_to_be_removed)
 
     def block_call(self, cmd):
-        raise RuntimeError("Unsupported method. You may use an unsupported combination of the machine and the context.")
+        raise RuntimeError(
+            "Unsupported method. You may use an unsupported combination of the machine and the context."
+        )

--- a/dpdispatcher/contexts/ssh_context.py
+++ b/dpdispatcher/contexts/ssh_context.py
@@ -767,41 +767,6 @@ class SSHContext(BaseContext):
                 tar_compress=self.remote_profile.get("tar_compress", None),
             )
 
-    def block_checkcall(self, cmd, asynchronously=False, stderr_whitelist=None):
-        """Run command with arguments. Wait for command to complete. If the return code
-        was zero then return, otherwise raise RuntimeError.
-
-        Parameters
-        ----------
-        cmd : str
-            The command to run.
-        asynchronously : bool, optional, default=False
-            Run command asynchronously. If True, `nohup` will be used to run the command.
-        stderr_whitelist : list of str, optional, default=None
-            If not None, the stderr will be checked against the whitelist. If the stderr
-            contains any of the strings in the whitelist, the command will be considered
-            successful.
-        """
-        assert self.remote_root is not None
-        self.ssh_session.ensure_alive()
-        if asynchronously:
-            cmd = f"nohup {cmd} >/dev/null &"
-        stdin, stdout, stderr = self.ssh_session.exec_command(
-            (f"cd {shlex.quote(self.remote_root)} ;") + cmd
-        )
-        exit_status = stdout.channel.recv_exit_status()
-        if exit_status != 0:
-            raise RuntimeError(
-                "Get error code %d in calling %s through ssh with job: %s . message: %s"
-                % (
-                    exit_status,
-                    cmd,
-                    self.submission.submission_hash,
-                    stderr.read().decode("utf-8"),
-                )
-            )
-        return stdin, stdout, stderr
-
     def block_call(self, cmd):
         assert self.remote_root is not None
         self.ssh_session.ensure_alive()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new `block_call` methods in various contexts to enhance error handling for unsupported operations.
	- Added `block_checkcall` method to allow for asynchronous command execution in certain contexts.
  
- **Bug Fixes**
	- Enhanced error feedback when unsupported operations are attempted in several contexts.

- **Chores**
	- Removed the `block_checkcall` method from multiple contexts, simplifying command execution and error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->