### PR TITLE
Fix code scanning alert no. 4: Arbitrary file write during tarfile extraction

### DIFF
--- a/dpdispatcher/contexts/ssh_context.py
+++ b/dpdispatcher/contexts/ssh_context.py
@@ -972,6 +972,9 @@ class SSHContext(BaseContext):
         self.ssh_session.get(from_f, to_f)
         # extract
         with tarfile.open(to_f, mode=tarfile_mode) as tar:
+            for member in tar.getmembers():
+                if os.path.isabs(member.name) or ".." in member.name:
+                    raise ValueError(f"Illegal tar archive entry: {member.name}")
             tar.extractall(path=self.local_root)
         # cleanup
         os.remove(to_f)


### PR DESCRIPTION
Fixes [https://github.com/deepmodeling/dpdispatcher/security/code-scanning/4](https://github.com/deepmodeling/dpdispatcher/security/code-scanning/4)

To fix the problem, we need to ensure that the paths of the files within the tar archive do not contain any directory traversal elements (`..`). This can be done by checking each file path before extraction and raising an error if any path is found to be unsafe.

**Steps to fix:**
1. **Check Paths**: Before extracting each file, check if the path is absolute or contains `..`. If it does, raise an error.
2. **Modify Extraction Logic**: Update the extraction logic to include this validation step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security with validation in file extraction to prevent directory traversal attacks.
	- Improved file upload handling with SHA256 checksum generation for integrity verification.
	- File transfer efficiency increased by utilizing `rsync` when available.

- **Bug Fixes**
	- Ensured SSH session is alive before executing commands with a retry mechanism.

- **Documentation**
	- Updated method signatures and documentation to reflect current implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->