### PR TITLE
Fix code scanning alert no. 3: Arbitrary file write during tarfile extraction

### DIFF
--- a/dpdispatcher/contexts/hdfs_context.py
+++ b/dpdispatcher/contexts/hdfs_context.py
@@ -144,6 +144,10 @@ class HDFSContext(BaseContext):
         tgz_file_list = glob(os.path.join(self.local_root, "tmp/*_download.tar.gz"))
         for tgz in tgz_file_list:
             with tarfile.open(tgz, "r:gz") as tar:
+                for member in tar.getmembers():
+                    member_path = os.path.join(gz_dir, member.name)
+                    if os.path.isabs(member.name) or ".." in member.name:
+                        raise ValueError(f"Illegal tar archive entry: {member.name}")
                 tar.extractall(path=gz_dir)
 
         for task in submission.belonging_tasks:


### PR DESCRIPTION
Fixes [https://github.com/deepmodeling/dpdispatcher/security/code-scanning/3](https://github.com/deepmodeling/dpdispatcher/security/code-scanning/3)

To fix the problem, we need to ensure that the file paths within the tar archive are validated before extraction. Specifically, we should check that the paths do not contain any directory traversal elements (`..`) and are not absolute paths. This can be done by iterating over the members of the tar file and performing these checks before extraction.

**Steps to fix:**
1. Iterate over each member of the tar archive.
2. Check if the member's name is an absolute path or contains `..`.
3. If any member fails the check, raise an exception.
4. If all members pass the checks, proceed with extraction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
