### PR TITLE
ci: pin ubuntu to 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - '3.11'
           - '3.12'
         platform:
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-latest
           - windows-latest
         exclude:  # Apple Silicon ARM64 does not support Python < v3.8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to run tests on Ubuntu 22.04 specifically
	- Refined testing infrastructure to use a consistent operating system environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->