### PR TITLE
fix: add `--parsable` to `sbatch` command

### DIFF
--- a/dpdispatcher/machines/slurm.py
+++ b/dpdispatcher/machines/slurm.py
@@ -85,7 +85,7 @@ class Slurm(Machine):
         # self.context.write_file(fname=os.path.join(self.context.submission.work_base, script_file_name), write_str=script_str)
         command = "cd {} && {} {}".format(
             shlex.quote(self.context.remote_root),
-            "sbatch",
+            "sbatch --parsable",
             shlex.quote(script_file_name),
         )
         ret, stdin, stdout, stderr = self.context.block_call(command)


### PR DESCRIPTION
Fix #521.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the format of job submission output for Slurm jobs, making job information easier to parse after submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->