### PR TITLE
CI: Replace the macos-13 images with the macos-15-intel images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
             platform: macos-latest
         include:  # So run those legacy versions on Intel CPUs
           - python-version: "3.7"
-            platform: macos-13
+            platform: macos-15-intel
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
per https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to run the legacy Python 3.7 macOS job on the macOS-15-intel runner instead of macOS-13.
  * No changes to workflow logic, steps, or error handling.

* **Tests**
  * Infrastructure-only update to test runner environment; test coverage and behavior remain unchanged.

* **Notes**
  * No user-facing impact or functional changes to the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->