### PR TITLE
docs: prefer `uv run` in `dpdisp run`

### DIFF
--- a/examples/dpdisp_run.py
+++ b/examples/dpdisp_run.py
@@ -18,7 +18,9 @@
 # group_size = 0
 # [[tool.dpdispatcher.task_list]]
 # # no need to contain the script filename
-# command = "python"
+# # `uv run` supports dependencies declared in the PEP-723 format
+# # See: https://docs.astral.sh/uv/guides/scripts/
+# command = "uv run"
 # # can be a glob pattern
 # task_work_path = "./"
 # forward_files = []


### PR DESCRIPTION
Update the example to use `uv run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example task configuration to use an alternative Python task execution method.

* **Documentation**
  * Added comments documenting support for dependency declarations in PEP-723 format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->