### PR TITLE
docs: use `npx skills` to install the skill

### DIFF
--- a/doc/agent-skills.md
+++ b/doc/agent-skills.md
@@ -15,11 +15,10 @@ Users usually do not need to perform manual installation.
 
 ### If you are an agent
 
-1. Run the following commands in your workspace:
+1. Run the following command in your workspace:
    ```sh
-   npx -y skills add deepmodeling/dpdispatcher -a openclaw -y
-   ```
-   In this command, `openclaw` is the agent.
+   npx -y skills add deepmodeling/dpdispatcher -a <your-agent-name> -y
+   
    The command uses [the skill CLI](https://github.com/vercel-labs/skills) to clone [deepmodeling/dpdispatcher](https://github.com/deepmodeling/dpdispatcher) and copy skill directories from `skills/` into your workspace skills directory.
 1. Refresh/restart the session so skills are reloaded.
 

--- a/doc/agent-skills.md
+++ b/doc/agent-skills.md
@@ -18,8 +18,9 @@ Users usually do not need to perform manual installation.
 1. Run the following command in your workspace:
    ```sh
    npx -y skills add deepmodeling/dpdispatcher -a <your-agent-name> -y
-   
+
    The command uses [the skill CLI](https://github.com/vercel-labs/skills) to clone [deepmodeling/dpdispatcher](https://github.com/deepmodeling/dpdispatcher) and copy skill directories from `skills/` into your workspace skills directory.
+   ```
 1. Refresh/restart the session so skills are reloaded.
 
 ## Minimal verification

--- a/doc/agent-skills.md
+++ b/doc/agent-skills.md
@@ -15,9 +15,13 @@ Users usually do not need to perform manual installation.
 
 ### If you are an agent
 
-1. Clone [deepmodeling/dpdispatcher](https://github.com/deepmodeling/dpdispatcher).
-1. Copy required skill directories from `skills/` into your workspace skills directory.
-1. Refresh/restart session so skills are reloaded.
+1. Run the following commands in your workspace:
+   ```sh
+   npx -y skills add deepmodeling/dpdispatcher -a openclaw -y
+   ```
+   In this command, `openclaw` is the agent.
+   The command uses [the skill CLI](https://github.com/vercel-labs/skills) to clone [deepmodeling/dpdispatcher](https://github.com/deepmodeling/dpdispatcher) and copy skill directories from `skills/` into your workspace skills directory.
+1. Refresh/restart the session so skills are reloaded.
 
 ## Minimal verification
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated agent installation instructions to use a single Skill CLI command for adding the dispatcher skill: `npx -y skills add deepmodeling/dpdispatcher -a <your-agent-name> -y`. 
  * Retains the final session refresh/restart step to reload skills after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->