### PR TITLE
fix: make default Slurm CPU headers portable

### DIFF
--- a/doc/examples/expanse.md
+++ b/doc/examples/expanse.md
@@ -11,7 +11,7 @@ linenos:
 ---
 ```
 
-Expanse's standard compute nodes are each powered by two 64-core AMD EPYC 7742 processors and contain 256 GB of DDR4 memory. Here, we request one node with 32 cores and 16 GB memory from the `shared` partition. Expanse does not support `--gres=gpu:0` command, so we use {ref}`custom_gpu_line <resources[Slurm]/kwargs/custom_gpu_line>` to customize the statement.
+Expanse's standard compute nodes are each powered by two 64-core AMD EPYC 7742 processors and contain 256 GB of DDR4 memory. Here, we request one node with 32 cores and 16 GB memory from the `shared` partition. Since CPU Slurm jobs omit GPU directives by default, no GPU override is needed for this example. If a site requires an explicit GPU directive such as `--gpus=0`, use {ref}`custom_gpu_line <resources[Slurm]/kwargs/custom_gpu_line>` to customize the statement.
 
 ```{literalinclude} ../../examples/resources/expanse_cpu.json
 ---

--- a/dpdispatcher/machines/slurm.py
+++ b/dpdispatcher/machines/slurm.py
@@ -18,7 +18,6 @@ from dpdispatcher.utils.utils import (
 
 slurm_script_header_template = """\
 #!/bin/bash -l
-#SBATCH --parsable
 {slurm_nodes_line}
 {slurm_ntasks_per_node_line}
 {slurm_number_gpu_line}
@@ -36,7 +35,7 @@ class Slurm(Machine):
         slurm_script = super().gen_script(job)
         return slurm_script
 
-    def gen_script_header(self, job):
+    def gen_script_header(self, job) -> str:
         resources = job.resources
         script_header_dict = {}
         script_header_dict["slurm_nodes_line"] = (
@@ -46,12 +45,14 @@ class Slurm(Machine):
             f"#SBATCH --ntasks-per-node {resources.cpu_per_node}"
         )
         custom_gpu_line = resources.kwargs.get("custom_gpu_line", None)
-        if not custom_gpu_line:
+        if custom_gpu_line is not None:
+            script_header_dict["slurm_number_gpu_line"] = custom_gpu_line
+        elif resources.gpu_per_node > 0:
             script_header_dict["slurm_number_gpu_line"] = (
                 f"#SBATCH --gres=gpu:{resources.gpu_per_node}"
             )
         else:
-            script_header_dict["slurm_number_gpu_line"] = custom_gpu_line
+            script_header_dict["slurm_number_gpu_line"] = ""
         if resources.queue_name != "":
             script_header_dict["slurm_partition_line"] = (
                 f"#SBATCH --partition {resources.queue_name}"

--- a/examples/resources/expanse_cpu.json
+++ b/examples/resources/expanse_cpu.json
@@ -20,8 +20,5 @@
     "TF_INTER_OP_PARALLELISM_THREADS": 8,
     "DP_AUTO_PARALLELIZATION": 1
   },
-  "batch_type": "Slurm",
-  "kwargs": {
-    "custom_gpu_line": "#SBATCH --gpus=0"
-  }
+  "batch_type": "Slurm"
 }

--- a/examples/resources/template.slurm
+++ b/examples/resources/template.slurm
@@ -1,5 +1,4 @@
 #!/bin/bash -l
-#SBATCH --parsable
 #SBATCH --nodes={number_node}
 #SBATCH --ntasks-per-node={cpu_per_node}
 #SBATCH --qos={kwargs[qos]}

--- a/tests/test_slurm_script_generation.py
+++ b/tests/test_slurm_script_generation.py
@@ -9,12 +9,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 __package__ = "tests"
 import json
 import unittest
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
 
 from .context import (
     Machine,
     Resources,
-    Submission,
-    Task,
     setUpModule,  # noqa: F401
 )
 
@@ -23,63 +23,57 @@ class TestSlurmScriptGeneration(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
 
-    def test_shell_trival(self):
+    def _make_header(
+        self,
+        resource_updates: Optional[Dict[str, Any]] = None,
+        remove_resource_keys: Optional[List[str]] = None,
+    ) -> str:
         with open("jsons/machine_lazy_local_slurm.json") as f:
             machine_dict = json.load(f)
 
+        resource_updates = resource_updates or {}
+        remove_resource_keys = remove_resource_keys or []
+        for key in remove_resource_keys:
+            machine_dict["resources"].pop(key, None)
+        machine_dict["resources"].update(resource_updates)
+
         machine = Machine(**machine_dict["machine"])
         resources = Resources(**machine_dict["resources"])
+        return machine.gen_script_header(SimpleNamespace(resources=resources))
 
-        task1 = Task(
-            command="cat example.txt",
-            task_work_path="dir1/",
-            forward_files=["example.txt"],
-            backward_files=["out.txt"],
-            outlog="out.txt",
-        )
-        task2 = Task(
-            command="cat example.txt",
-            task_work_path="dir2/",
-            forward_files=["example.txt"],
-            backward_files=["out.txt"],
-            outlog="out.txt",
-        )
-        task3 = Task(
-            command="cat example.txt",
-            task_work_path="dir3/",
-            forward_files=["example.txt"],
-            backward_files=["out.txt"],
-            outlog="out.txt",
-        )
-        task4 = Task(
-            command="cat example.txt",
-            task_work_path="dir4/",
-            forward_files=["example.txt"],
-            backward_files=["out.txt"],
-            outlog="out.txt",
-        )
-        task_list = [task1, task2, task3, task4]
-
-        submission = Submission(
-            work_base="parent_dir/",
-            machine=machine,
-            resources=resources,
-            forward_common_files=["graph.pb"],
-            backward_common_files=[],
-            task_list=task_list,
-        )
-        submission.generate_jobs()
-        str = machine.gen_script_header(submission.belonging_jobs[0])
+    def test_shell_trival(self):
+        header = self._make_header()
         benchmark_str = textwrap.dedent(
             """\
             #!/bin/bash -l
-            #SBATCH --parsable
             #SBATCH --nodes 1
             #SBATCH --ntasks-per-node 4
             #SBATCH --gres=gpu:2080Ti:2
             #SBATCH --partition GPU_2080Ti"""
         )
-        self.assertEqual(str, benchmark_str)
+        self.assertEqual(header, benchmark_str)
+
+    def test_cpu_header_omits_gpu_request(self):
+        header = self._make_header(
+            resource_updates={
+                "gpu_per_node": 0,
+                "queue_name": "CPU",
+                "strategy": {"if_cuda_multi_devices": False},
+            },
+            remove_resource_keys=["custom_gpu_line"],
+        )
+
+        self.assertIn("#!/bin/bash -l", header)
+        self.assertNotIn("#SBATCH --parsable", header)
+        self.assertNotIn("#SBATCH --gres=gpu:0", header)
+        self.assertIn("#SBATCH --nodes 1", header)
+        self.assertIn("#SBATCH --ntasks-per-node 4", header)
+        self.assertIn("#SBATCH --partition CPU", header)
+
+    def test_gpu_header_uses_default_gres_when_requested(self):
+        header = self._make_header(remove_resource_keys=["custom_gpu_line"])
+
+        self.assertIn("#SBATCH --gres=gpu:2", header)
 
     @unittest.skipIf(sys.platform == "win32", "skip for persimission error")
     def test_template(self):
@@ -89,7 +83,6 @@ class TestSlurmScriptGeneration(unittest.TestCase):
         benchmark_str = textwrap.dedent(
             """\
             #!/bin/bash -l
-            #SBATCH --parsable
             #SBATCH --nodes 1
             #SBATCH --ntasks-per-node 4
             #SBATCH --gres=gpu:2080Ti:2
@@ -106,45 +99,5 @@ class TestSlurmScriptGeneration(unittest.TestCase):
 
             machine = Machine(**machine_dict["machine"])
             resources = Resources(**machine_dict["resources"])
-
-            task1 = Task(
-                command="cat example.txt",
-                task_work_path="dir1/",
-                forward_files=["example.txt"],
-                backward_files=["out.txt"],
-                outlog="out.txt",
-            )
-            task2 = Task(
-                command="cat example.txt",
-                task_work_path="dir2/",
-                forward_files=["example.txt"],
-                backward_files=["out.txt"],
-                outlog="out.txt",
-            )
-            task3 = Task(
-                command="cat example.txt",
-                task_work_path="dir3/",
-                forward_files=["example.txt"],
-                backward_files=["out.txt"],
-                outlog="out.txt",
-            )
-            task4 = Task(
-                command="cat example.txt",
-                task_work_path="dir4/",
-                forward_files=["example.txt"],
-                backward_files=["out.txt"],
-                outlog="out.txt",
-            )
-            task_list = [task1, task2, task3, task4]
-
-            submission = Submission(
-                work_base="parent_dir/",
-                machine=machine,
-                resources=resources,
-                forward_common_files=["graph.pb"],
-                backward_common_files=[],
-                task_list=task_list,
-            )
-            submission.generate_jobs()
-            str = machine.gen_script_header(submission.belonging_jobs[0])
-            self.assertEqual(str, benchmark_str)
+            header = machine.gen_script_header(SimpleNamespace(resources=resources))
+            self.assertEqual(header, benchmark_str)


### PR DESCRIPTION
Avoid login-shell and GPU directives for CPU Slurm jobs so generated scripts work on clusters with stricter compute-node environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed login-shell (-l) from script shebang and stopped embedding the parsable flag in headers for more predictable submissions.
  * GPU request logic now omits GPU directives for CPU jobs and respects explicit empty overrides when provided.

* **Documentation**
  * Clarified guidance about login-shell effects and that GPU directives are omitted by default for CPU jobs.

* **Tests**
  * Improved Slurm header tests for clearer, more targeted coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepmodeling/dpdispatcher/pull/596)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->