### PR TITLE
feat: add login_shell option for bash headers

### DIFF
--- a/doc/context.md
+++ b/doc/context.md
@@ -10,6 +10,7 @@ One needs to set {dargs:argument}`context_type <machine/context_type>` to one of
 `LazyLocal` directly runs jobs in the local server and local directory.
 
 Since [`bash -l`](https://www.gnu.org/software/bash/manual/bash.html#Invoking-Bash) is used in the shebang line of the submission scripts, the [login shell startup files](https://www.gnu.org/software/bash/manual/bash.html#Invoking-Bash) will be executed, potentially overriding the current environment variables. Therefore, it's advisable to explicitly set the environment variables using {dargs:argument}`envs <resources/envs>` or {dargs:argument}`source_list <resources/source_list>`.
+For backends that generate Bash submission scripts, set `kwargs.login_shell` to `false` to use `#!/bin/bash` instead of `#!/bin/bash -l`. User-provided script header templates control their own shebang line.
 
 ## Local
 
@@ -20,6 +21,7 @@ Files will be symlinked to the remote directory before jobs start and copied bac
 If the local directory is not accessible with the [batch system](./batch.md), turn off {dargs:argument}`symlink <machine[LocalContext]/remote_profile/symlink>`, and then files on the local directory will be copied to the remote directory.
 
 Since [`bash -l`](https://www.gnu.org/software/bash/manual/bash.html#Invoking-Bash) is used in the shebang line of the submission scripts, the [login shell startup files](https://www.gnu.org/software/bash/manual/bash.html#Invoking-Bash) will be executed, potentially overriding the current environment variables. Therefore, it's advisable to explicitly set the environment variables using {dargs:argument}`envs <resources/envs>` or {dargs:argument}`source_list <resources/source_list>`.
+For backends that generate Bash submission scripts, set `kwargs.login_shell` to `false` to use `#!/bin/bash` instead of `#!/bin/bash -l`. User-provided script header templates control their own shebang line.
 
 ## SSH
 

--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -223,6 +223,12 @@ class Machine(metaclass=ABCMeta):
             "abstract method do_submit should be implemented by derived class"
         )
 
+    @staticmethod
+    def apply_login_shell_option(script_header: str, resources) -> str:
+        if resources.kwargs.get("login_shell", True):
+            return script_header
+        return script_header.replace("#!/bin/bash -l", "#!/bin/bash", 1)
+
     def gen_script_run_command(self, job):
         return f"source $REMOTE_ROOT/{job.script_file_name}.run"
 
@@ -496,7 +502,14 @@ class Machine(metaclass=ABCMeta):
         """
         return [
             Argument(
-                "kwargs", dict, optional=True, doc="This field is empty for this batch."
+                "kwargs",
+                dict,
+                optional=True,
+                doc=(
+                    "Machine-specific settings. For Bash submission scripts, "
+                    "set login_shell to false to use #!/bin/bash instead of "
+                    "#!/bin/bash -l."
+                ),
             )
         ]
 

--- a/dpdispatcher/machines/JH_UniScheduler.py
+++ b/dpdispatcher/machines/JH_UniScheduler.py
@@ -52,8 +52,9 @@ class JH_UniScheduler(Machine):
                 resources,
             )
         else:
-            JH_UniScheduler_script_header = (
-                JH_UniScheduler_script_header_template.format(**script_header_dict)
+            JH_UniScheduler_script_header = self.apply_login_shell_option(
+                JH_UniScheduler_script_header_template.format(**script_header_dict),
+                resources,
             )
 
         return JH_UniScheduler_script_header

--- a/dpdispatcher/machines/distributed_shell.py
+++ b/dpdispatcher/machines/distributed_shell.py
@@ -125,7 +125,9 @@ class DistributedShell(Machine):
                 resources,
             )
         else:
-            shell_script_header = shell_script_header_template
+            shell_script_header = self.apply_login_shell_option(
+                shell_script_header_template, resources
+            )
         return shell_script_header
 
     def do_submit(self, job):

--- a/dpdispatcher/machines/dp_cloud_server.py
+++ b/dpdispatcher/machines/dp_cloud_server.py
@@ -82,7 +82,9 @@ class Bohrium(Machine):
                 resources,
             )
         else:
-            shell_script_header = shell_script_header_template
+            shell_script_header = self.apply_login_shell_option(
+                shell_script_header_template, resources
+            )
         return shell_script_header
 
     def gen_local_script(self, job):

--- a/dpdispatcher/machines/lsf.py
+++ b/dpdispatcher/machines/lsf.py
@@ -71,7 +71,9 @@ class LSF(Machine):
                 resources,
             )
         else:
-            lsf_script_header = lsf_script_header_template.format(**script_header_dict)
+            lsf_script_header = self.apply_login_shell_option(
+                lsf_script_header_template.format(**script_header_dict), resources
+            )
 
         return lsf_script_header
 

--- a/dpdispatcher/machines/openapi.py
+++ b/dpdispatcher/machines/openapi.py
@@ -86,7 +86,9 @@ class OpenAPI(Machine):
                 resources,
             )
         else:
-            shell_script_header = shell_script_header_template
+            shell_script_header = self.apply_login_shell_option(
+                shell_script_header_template, resources
+            )
         return shell_script_header
 
     def gen_local_script(self, job):

--- a/dpdispatcher/machines/pbs.py
+++ b/dpdispatcher/machines/pbs.py
@@ -44,8 +44,8 @@ class PBS(Machine):
                 resources,
             )
         else:
-            pbs_script_header = pbs_script_header_template.format(
-                **pbs_script_header_dict
+            pbs_script_header = self.apply_login_shell_option(
+                pbs_script_header_template.format(**pbs_script_header_dict), resources
             )
         return pbs_script_header
 
@@ -176,8 +176,8 @@ class Torque(PBS):
                 resources,
             )
         else:
-            pbs_script_header = pbs_script_header_template.format(
-                **pbs_script_header_dict
+            pbs_script_header = self.apply_login_shell_option(
+                pbs_script_header_template.format(**pbs_script_header_dict), resources
             )
         return pbs_script_header
 

--- a/dpdispatcher/machines/shell.py
+++ b/dpdispatcher/machines/shell.py
@@ -26,7 +26,9 @@ class Shell(Machine):
                 resources,
             )
         else:
-            shell_script_header = shell_script_header_template
+            shell_script_header = self.apply_login_shell_option(
+                shell_script_header_template, resources
+            )
         return shell_script_header
 
     def do_submit(self, job):

--- a/dpdispatcher/machines/slurm.py
+++ b/dpdispatcher/machines/slurm.py
@@ -67,8 +67,8 @@ class Slurm(Machine):
                 resources,
             )
         else:
-            slurm_script_header = slurm_script_header_template.format(
-                **script_header_dict
+            slurm_script_header = self.apply_login_shell_option(
+                slurm_script_header_template.format(**script_header_dict), resources
             )
         return slurm_script_header
 

--- a/tests/test_login_shell_option.py
+++ b/tests/test_login_shell_option.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+__package__ = "tests"
+
+from .context import (
+    Machine,
+    Resources,
+    setUpModule,  # noqa: F401
+)
+
+
+class TestLoginShellOption(unittest.TestCase):
+    def _make_header(self, batch_type: str, login_shell: bool) -> str:
+        machine = Machine(
+            batch_type=batch_type,
+            context_type="LazyLocalContext",
+            local_root="./test_context_dir",
+        )
+        resources = Resources(
+            number_node=1,
+            cpu_per_node=1,
+            gpu_per_node=0,
+            queue_name="queue",
+            group_size=1,
+            kwargs={"login_shell": login_shell},
+        )
+        return machine.gen_script_header(SimpleNamespace(resources=resources))
+
+    def test_login_shell_enabled_by_default(self):
+        resources = Resources(
+            number_node=1,
+            cpu_per_node=1,
+            gpu_per_node=0,
+            queue_name="queue",
+            group_size=1,
+        )
+
+        header = Machine.apply_login_shell_option("#!/bin/bash -l\n", resources)
+
+        self.assertEqual(header, "#!/bin/bash -l\n")
+
+    def test_login_shell_can_be_disabled_for_shell(self):
+        header = self._make_header("Shell", login_shell=False)
+
+        self.assertIn("#!/bin/bash\n", header)
+        self.assertNotIn("#!/bin/bash -l", header)
+
+    def test_login_shell_can_be_disabled_for_slurm(self):
+        header = self._make_header("Slurm", login_shell=False)
+
+        self.assertIn("#!/bin/bash\n", header)
+        self.assertNotIn("#!/bin/bash -l", header)
+
+    def test_login_shell_can_be_disabled_for_pbs(self):
+        header = self._make_header("PBS", login_shell=False)
+
+        self.assertIn("#!/bin/bash\n", header)
+        self.assertNotIn("#!/bin/bash -l", header)
+
+    def test_login_shell_can_be_disabled_for_lsf(self):
+        header = self._make_header("LSF", login_shell=False)
+
+        self.assertIn("#!/bin/bash\n", header)
+        self.assertNotIn("#!/bin/bash -l", header)


### PR DESCRIPTION
Allow generated Bash submission headers to opt out of login-shell startup files while preserving the current default behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `login_shell` option to resource configuration. Controls whether Bash submission scripts use `#!/bin/bash -l` (default) or `#!/bin/bash` across batch schedulers (Shell, Slurm, PBS, LSF, and others).

* **Tests**
  * Added unit tests validating the login shell configuration option across multiple batch types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepmodeling/dpdispatcher/pull/597)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->