### PR TITLE
feat: automatically download error diagnostic files for failed jobs

### DIFF
--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -102,6 +102,13 @@ class Machine(metaclass=ABCMeta):
     def bind_context(self, context):
         self.context = context
 
+    def get_job_error(self, job):
+        """Return the saved error diagnostic for a job, if available."""
+        error_file = job.job_hash + "_last_err_file"
+        if self.context.check_file_exists(error_file):
+            return self.context.read_file(error_file)
+        return None
+
     # def __init__ (self,
     #             context):
     #     self.context = context

--- a/dpdispatcher/machines/dp_cloud_server.py
+++ b/dpdispatcher/machines/dp_cloud_server.py
@@ -103,6 +103,7 @@ class Bohrium(Machine):
             result_file_list.extend(
                 [os.path.join(task.task_work_path, b_f) for b_f in task.backward_files]
             )
+        result_file_list.append(job.job_hash + "_last_err_file")
         result_file_list = list(set(result_file_list))
         return result_file_list
 
@@ -136,6 +137,11 @@ class Bohrium(Machine):
         input_data["command"] = f"bash {job.script_file_name}"
         if not input_data.get("backward_files"):
             input_data["backward_files"] = self._gen_backward_files_list(job)
+        else:
+            input_data["backward_files"] = list(input_data["backward_files"])
+            error_file = job.job_hash + "_last_err_file"
+            if error_file not in input_data["backward_files"]:
+                input_data["backward_files"].append(error_file)
         input_data["logFiles"] = os.path.join(
             job.job_task_list[0].task_work_path, job.job_task_list[0].outlog
         )
@@ -238,6 +244,27 @@ class Bohrium(Machine):
             )
         except (OSError, shutil.Error) as e:
             dlog.exception("unable to backup file, " + str(e))
+
+    def get_job_error(self, job):
+        """Retrieve diagnostics from the cloud result or job log."""
+        try:
+            self._download_job(job)
+        except Exception as e:
+            dlog.debug(f"Could not download result archive for job {job.job_hash}: {e}")
+        error_path = os.path.join(
+            self.context.local_root, job.job_hash + "_last_err_file"
+        )
+        if os.path.isfile(error_path):
+            with open(error_path) as fp:
+                return fp.read()
+        job_id = job.job_id
+        if isinstance(job_id, str) and ":job_group_id:" in job_id:
+            job_id = int(job_id.split(":job_group_id:", 1)[0])
+        try:
+            return self.api.get_log(job_id)
+        except Exception as e:
+            dlog.debug(f"Could not retrieve cloud log for job {job.job_hash}: {e}")
+            return None
 
     def check_finish_tag(self, job):
         job_tag_finished = job.job_hash + "_job_tag_finished"

--- a/dpdispatcher/machines/openapi.py
+++ b/dpdispatcher/machines/openapi.py
@@ -107,6 +107,7 @@ class OpenAPI(Machine):
             result_file_list.extend(
                 [os.path.join(task.task_work_path, b_f) for b_f in task.backward_files]
             )
+        result_file_list.append(job.job_hash + "_last_err_file")
         result_file_list = list(set(result_file_list))
         return result_file_list
 
@@ -196,7 +197,7 @@ class OpenAPI(Machine):
 
     def _download_job(self, job):
         data = self.job.detail(job.job_id)
-        job_url = data["resultUrl"]
+        job_url = data.get("resultUrl")
         if not job_url:
             return
         job_hash = job.job_hash
@@ -216,6 +217,24 @@ class OpenAPI(Machine):
             )
         except (OSError, shutil.Error) as e:
             dlog.exception("unable to backup file, " + str(e))
+
+    def get_job_error(self, job):
+        """Retrieve diagnostics from the cloud result or job log."""
+        try:
+            self._download_job(job)
+        except Exception as e:
+            dlog.debug(f"Could not download result archive for job {job.job_hash}: {e}")
+        error_path = os.path.join(
+            self.context.local_root, job.job_hash + "_last_err_file"
+        )
+        if os.path.isfile(error_path):
+            with open(error_path) as fp:
+                return fp.read()
+        try:
+            return self.job.log(job.job_id)
+        except Exception as e:
+            dlog.debug(f"Could not retrieve cloud log for job {job.job_hash}: {e}")
+            return None
 
     def check_finish_tag(self, job):
         job_tag_finished = job.job_hash + "_job_tag_finished"

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -260,10 +260,53 @@ class Submission:
                 pass
         self.handle_unexpected_submission_state()
         self.try_download_result()
+        self.try_download_error_info()
         self.submission_to_json()
         if clean:
             self.clean_jobs()
         return self.serialize()
+
+    def try_download_error_info(self):
+        """Download error diagnostic files for failed/terminated jobs.
+
+        For each job that did not finish successfully, attempts to download
+        the ``{job_hash}_last_err_file`` from the remote root to the local root.
+        This preserves error diagnostics even when ``clean=True`` deletes the
+        remote workdir afterward.
+
+        The error file contains the last 1000 bytes of stderr from the most
+        recently failed task in the job, written by the generated bash script.
+        """
+        if self.machine is None:
+            return
+        for job in self.belonging_jobs:
+            if job.job_state != JobStatus.finished:
+                err_file_name = job.job_hash + "_last_err_file"
+                try:
+                    if self.machine.context.check_file_exists(err_file_name):
+                        err_content = self.machine.context.read_file(err_file_name)
+                        # Write to local root for post-mortem access
+                        local_err_path = os.path.join(
+                            self.machine.context.local_root, err_file_name
+                        )
+                        os.makedirs(
+                            os.path.dirname(local_err_path), exist_ok=True
+                        )
+                        with open(local_err_path, "w") as f:
+                            f.write(err_content)
+                        dlog.info(
+                            f"Downloaded error info for job {job.job_hash} to "
+                            f"{local_err_path}"
+                        )
+                        # Also log the error content for immediate visibility
+                        dlog.warning(
+                            f"Job {job.job_hash} failed. Last error output:\n"
+                            f"{err_content}"
+                        )
+                except Exception as e:
+                    dlog.debug(
+                        f"Could not download error file for job {job.job_hash}: {e}"
+                    )
 
     def try_download_result(self):
         start_time = time.time()

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -289,9 +289,7 @@ class Submission:
                         local_err_path = os.path.join(
                             self.machine.context.local_root, err_file_name
                         )
-                        os.makedirs(
-                            os.path.dirname(local_err_path), exist_ok=True
-                        )
+                        os.makedirs(os.path.dirname(local_err_path), exist_ok=True)
                         with open(local_err_path, "w") as f:
                             f.write(err_content)
                         dlog.info(

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -290,8 +290,8 @@ class Submission:
             if job.job_state in (JobStatus.terminated, JobStatus.unknown):
                 err_file_name = job.job_hash + "_last_err_file"
                 try:
-                    if self.machine.context.check_file_exists(err_file_name):
-                        err_content = self.machine.context.read_file(err_file_name)
+                    err_content = self.machine.get_job_error(job)
+                    if err_content is not None:
                         # Write to local root for post-mortem access
                         local_err_path = os.path.join(
                             self.machine.context.local_root, err_file_name
@@ -1028,9 +1028,8 @@ class Job:
     def get_last_error_message(self) -> Optional[str]:
         """Get last error message when the job is terminated."""
         assert self.machine is not None
-        last_err_file = self.job_hash + "_last_err_file"
-        if self.machine.context.check_file_exists(last_err_file):
-            last_error_message = self.machine.context.read_file(last_err_file)
+        last_error_message = self.machine.get_job_error(self)
+        if last_error_message is not None:
             # red color
             last_error_message = "\033[31m" + last_error_message + "\033[0m"
             return last_error_message

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -233,34 +233,46 @@ class Submission:
             self.handle_unexpected_submission_state()
 
         ratio_unfinished = self.resources.strategy["ratio_unfinished"]
-        while not self.check_all_finished():
-            if exit_on_submit is True:
-                dlog.info(f"submission succeeded: {self.submission_hash}")
-                dlog.info(f"at {self.machine.context.remote_root}")
-                return self.serialize()
-            if ratio_unfinished > 0.0 and self.check_ratio_unfinished(ratio_unfinished):
-                self.remove_unfinished_tasks()
-                break
+        try:
+            while not self.check_all_finished():
+                if exit_on_submit is True:
+                    dlog.info(f"submission succeeded: {self.submission_hash}")
+                    dlog.info(f"at {self.machine.context.remote_root}")
+                    return self.serialize()
+                if ratio_unfinished > 0.0 and self.check_ratio_unfinished(
+                    ratio_unfinished
+                ):
+                    self.remove_unfinished_tasks()
+                    break
 
+                try:
+                    time.sleep(check_interval)
+                except (Exception, KeyboardInterrupt, SystemExit) as e:
+                    self.submission_to_json()
+                    record_path = record.write(self)
+                    dlog.exception(e)
+                    dlog.info(f"submission exit: {self.submission_hash}")
+                    dlog.info(f"at {self.machine.context.remote_root}")
+                    dlog.info(
+                        f"Submission information is saved in {str(record_path)}."
+                    )
+                    dlog.debug(self.serialize())
+                    raise e
+                else:
+                    self.update_submission_state()
+                    self.handle_unexpected_submission_state()
+                finally:
+                    pass
+            self.handle_unexpected_submission_state()
+            self.try_download_result()
+        finally:
+            # Always attempt error diagnostics download, even on failure paths
+            # (e.g. when handle_unexpected_submission_state raises RuntimeError
+            # after exhausting retries).
             try:
-                time.sleep(check_interval)
-            except (Exception, KeyboardInterrupt, SystemExit) as e:
-                self.submission_to_json()
-                record_path = record.write(self)
-                dlog.exception(e)
-                dlog.info(f"submission exit: {self.submission_hash}")
-                dlog.info(f"at {self.machine.context.remote_root}")
-                dlog.info(f"Submission information is saved in {str(record_path)}.")
-                dlog.debug(self.serialize())
-                raise e
-            else:
-                self.update_submission_state()
-                self.handle_unexpected_submission_state()
-            finally:
+                self.try_download_error_info()
+            except Exception:
                 pass
-        self.handle_unexpected_submission_state()
-        self.try_download_result()
-        self.try_download_error_info()
         self.submission_to_json()
         if clean:
             self.clean_jobs()

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -259,8 +259,6 @@ class Submission:
                 else:
                     self.update_submission_state()
                     self.handle_unexpected_submission_state()
-                finally:
-                    pass
             self.handle_unexpected_submission_state()
             self.try_download_result()
         finally:
@@ -276,7 +274,7 @@ class Submission:
             self.clean_jobs()
         return self.serialize()
 
-    def try_download_error_info(self):
+    def try_download_error_info(self) -> None:
         """Download error diagnostic files for failed/terminated jobs.
 
         For each job that did not finish successfully, attempts to download
@@ -290,7 +288,7 @@ class Submission:
         if self.machine is None:
             return
         for job in self.belonging_jobs:
-            if job.job_state != JobStatus.finished:
+            if job.job_state in (JobStatus.terminated, JobStatus.unknown):
                 err_file_name = job.job_hash + "_last_err_file"
                 try:
                     if self.machine.context.check_file_exists(err_file_name):

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -253,9 +253,7 @@ class Submission:
                     dlog.exception(e)
                     dlog.info(f"submission exit: {self.submission_hash}")
                     dlog.info(f"at {self.machine.context.remote_root}")
-                    dlog.info(
-                        f"Submission information is saved in {str(record_path)}."
-                    )
+                    dlog.info(f"Submission information is saved in {str(record_path)}.")
                     dlog.debug(self.serialize())
                     raise e
                 else:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -214,26 +214,26 @@ class Submission:
         assert self.resources is not None
         if not self.belonging_jobs:
             self.generate_jobs()
-        self.try_recover_from_json()
-        self.update_submission_state()
-        if self.check_all_finished():
-            dlog.info("check_all_finished: True")
-        else:
-            dlog.info("check_all_finished: False")
-            self.upload_jobs()
-            if dry_run is True:
-                dlog.info(f"submission succeeded: {self.submission_hash}")
-                dlog.info(f"at {self.machine.context.remote_root}")
-                return self.serialize()
-            self.handle_unexpected_submission_state()
-            self.submission_to_json()
-            time.sleep(1)
-            self.update_submission_state()
-            self.check_all_finished()
-            self.handle_unexpected_submission_state()
-
-        ratio_unfinished = self.resources.strategy["ratio_unfinished"]
         try:
+            self.try_recover_from_json()
+            self.update_submission_state()
+            if self.check_all_finished():
+                dlog.info("check_all_finished: True")
+            else:
+                dlog.info("check_all_finished: False")
+                self.upload_jobs()
+                if dry_run is True:
+                    dlog.info(f"submission succeeded: {self.submission_hash}")
+                    dlog.info(f"at {self.machine.context.remote_root}")
+                    return self.serialize()
+                self.handle_unexpected_submission_state()
+                self.submission_to_json()
+                time.sleep(1)
+                self.update_submission_state()
+                self.check_all_finished()
+                self.handle_unexpected_submission_state()
+
+            ratio_unfinished = self.resources.strategy["ratio_unfinished"]
             while not self.check_all_finished():
                 if exit_on_submit is True:
                     dlog.info(f"submission succeeded: {self.submission_hash}")
@@ -262,9 +262,8 @@ class Submission:
             self.handle_unexpected_submission_state()
             self.try_download_result()
         finally:
-            # Always attempt error diagnostics download, even on failure paths
-            # (e.g. when handle_unexpected_submission_state raises RuntimeError
-            # after exhausting retries).
+            # Cover recovery, initial submission, polling, and final download
+            # failures so exhausted retries always preserve diagnostics.
             try:
                 self.try_download_error_info()
             except Exception:

--- a/tests/test_cloud_job_error.py
+++ b/tests/test_cloud_job_error.py
@@ -53,7 +53,7 @@ class TestCloudJobError(unittest.TestCase):
 
         machine.do_submit(self.job)
 
-        input_data = machine.api.job_create.call_args.kwargs["input_data"]
+        input_data = machine.api.job_create.call_args[1]["input_data"]
         self.assertEqual(
             input_data["backward_files"], ["custom.log", "cloud-job_last_err_file"]
         )

--- a/tests/test_cloud_job_error.py
+++ b/tests/test_cloud_job_error.py
@@ -1,0 +1,99 @@
+"""Regression tests for cloud error diagnostics."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from dpdispatcher.machines.dp_cloud_server import Bohrium
+from dpdispatcher.machines.openapi import OpenAPI
+
+
+class TestCloudJobError(unittest.TestCase):
+    """Cloud machines retrieve diagnostics through the job interface."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.job = MagicMock(
+            job_hash="cloud-job",
+            job_id="123:job_group_id:456",
+            job_task_list=[],
+        )
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_backward_lists_include_diagnostic(self):
+        expected = "cloud-job_last_err_file"
+        for machine_class in (OpenAPI, Bohrium):
+            with self.subTest(machine=machine_class.__name__):
+                machine = machine_class.__new__(machine_class)
+                self.assertIn(
+                    expected,
+                    machine._gen_backward_files_list(self.job),
+                )
+
+    def test_bohrium_custom_backward_list_keeps_diagnostic(self):
+        machine = Bohrium.__new__(Bohrium)
+        machine.context = MagicMock()
+        machine.context.remote_profile = {"program_id": 1}
+        machine.input_data = {
+            "job_type": "container",
+            "backward_files": ["custom.log"],
+        }
+        machine.group_id = None
+        machine.grouped = False
+        machine.api = MagicMock()
+        machine.api.job_create.return_value = (123, 456)
+        machine.gen_local_script = MagicMock()
+        self.job.upload_path = "program/1/cloud-job.zip"
+        self.job.script_file_name = "cloud-job.sh"
+        self.job.job_id = ""
+        self.job.job_task_list = [MagicMock(task_work_path="task0", outlog="task0.out")]
+
+        machine.do_submit(self.job)
+
+        input_data = machine.api.job_create.call_args.kwargs["input_data"]
+        self.assertEqual(
+            input_data["backward_files"], ["custom.log", "cloud-job_last_err_file"]
+        )
+
+    def test_reads_diagnostic_from_result_archive(self):
+        error_path = os.path.join(self.tmpdir.name, "cloud-job_last_err_file")
+        for machine_class in (OpenAPI, Bohrium):
+            with self.subTest(machine=machine_class.__name__):
+                if os.path.exists(error_path):
+                    os.remove(error_path)
+                machine = machine_class.__new__(machine_class)
+                machine.context = MagicMock(local_root=self.tmpdir.name)
+
+                def download(_job):
+                    with open(error_path, "w") as fp:
+                        fp.write("remote stderr")
+
+                machine._download_job = MagicMock(side_effect=download)
+                machine.job = MagicMock()
+                machine.api = MagicMock()
+                self.assertEqual(
+                    machine.get_job_error(self.job),
+                    "remote stderr",
+                )
+
+    def test_falls_back_to_cloud_job_log(self):
+        for machine_class in (OpenAPI, Bohrium):
+            with self.subTest(machine=machine_class.__name__):
+                machine = machine_class.__new__(machine_class)
+                machine.context = MagicMock(local_root=self.tmpdir.name)
+                machine._download_job = MagicMock()
+                machine.job = MagicMock()
+                machine.job.log.return_value = "openapi log"
+                machine.api = MagicMock()
+                machine.api.get_log.return_value = "bohrium log"
+                expected = "openapi log" if machine_class is OpenAPI else "bohrium log"
+                self.assertEqual(machine.get_job_error(self.job), expected)
+                if machine_class is Bohrium:
+                    machine.api.get_log.assert_called_once_with(123)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_download_error_info.py
+++ b/tests/test_download_error_info.py
@@ -4,7 +4,7 @@ import os
 import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -15,7 +15,9 @@ from dpdispatcher.utils.job_status import JobStatus
 class TestDownloadErrorInfo(unittest.TestCase):
     """Unit tests for Submission.try_download_error_info()."""
 
-    def _make_submission(self, job_states, err_file_exists=True, err_content="LAMMPS error: lost atoms"):
+    def _make_submission(
+        self, job_states, err_file_exists=True, err_content="LAMMPS error: lost atoms"
+    ):
         """Create a Submission with mocked machine/context and jobs."""
         submission = Submission.__new__(Submission)
         submission.belonging_jobs = []
@@ -44,6 +46,7 @@ class TestDownloadErrorInfo(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         if hasattr(self, "_tmpdir") and os.path.exists(self._tmpdir):
             shutil.rmtree(self._tmpdir)
 
@@ -90,20 +93,22 @@ class TestDownloadErrorInfo(unittest.TestCase):
         sub.try_download_error_info()
 
         # Only job 1 (terminated) should have error file
-        self.assertFalse(os.path.exists(
-            os.path.join(self._tmpdir, "hash_0000_last_err_file")
-        ))
-        self.assertTrue(os.path.exists(
-            os.path.join(self._tmpdir, "hash_0001_last_err_file")
-        ))
-        self.assertFalse(os.path.exists(
-            os.path.join(self._tmpdir, "hash_0002_last_err_file")
-        ))
+        self.assertFalse(
+            os.path.exists(os.path.join(self._tmpdir, "hash_0000_last_err_file"))
+        )
+        self.assertTrue(
+            os.path.exists(os.path.join(self._tmpdir, "hash_0001_last_err_file"))
+        )
+        self.assertFalse(
+            os.path.exists(os.path.join(self._tmpdir, "hash_0002_last_err_file"))
+        )
 
     def test_context_exception_does_not_crash(self):
         """If context raises during error download, it's caught gracefully."""
         sub = self._make_submission([JobStatus.terminated])
-        sub.machine.context.check_file_exists = MagicMock(side_effect=OSError("network error"))
+        sub.machine.context.check_file_exists = MagicMock(
+            side_effect=OSError("network error")
+        )
 
         # Should not raise
         sub.try_download_error_info()

--- a/tests/test_download_error_info.py
+++ b/tests/test_download_error_info.py
@@ -1,0 +1,121 @@
+"""Test PR4: automatic download of error diagnostic files for failed jobs."""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dpdispatcher.submission import Submission
+from dpdispatcher.utils.job_status import JobStatus
+
+
+class TestDownloadErrorInfo(unittest.TestCase):
+    """Unit tests for Submission.try_download_error_info()."""
+
+    def _make_submission(self, job_states, err_file_exists=True, err_content="LAMMPS error: lost atoms"):
+        """Create a Submission with mocked machine/context and jobs."""
+        submission = Submission.__new__(Submission)
+        submission.belonging_jobs = []
+        submission.machine = MagicMock()
+
+        # Create a real temp dir as local_root
+        self._tmpdir = tempfile.mkdtemp()
+        submission.machine.context.local_root = self._tmpdir
+
+        def mock_check_file_exists(fname):
+            return err_file_exists
+
+        def mock_read_file(fname):
+            return err_content
+
+        submission.machine.context.check_file_exists = mock_check_file_exists
+        submission.machine.context.read_file = mock_read_file
+
+        for i, state in enumerate(job_states):
+            job = MagicMock()
+            job.job_state = state
+            job.job_hash = f"hash_{i:04d}"
+            submission.belonging_jobs.append(job)
+
+        return submission
+
+    def tearDown(self):
+        import shutil
+        if hasattr(self, "_tmpdir") and os.path.exists(self._tmpdir):
+            shutil.rmtree(self._tmpdir)
+
+    def test_downloads_error_for_terminated_job(self):
+        """Terminated job → error file should be downloaded to local root."""
+        sub = self._make_submission(
+            [JobStatus.terminated],
+            err_content="ERROR: Lost atoms (lammps)",
+        )
+        sub.try_download_error_info()
+
+        local_err_path = os.path.join(self._tmpdir, "hash_0000_last_err_file")
+        self.assertTrue(os.path.exists(local_err_path))
+        with open(local_err_path) as f:
+            content = f.read()
+        self.assertIn("Lost atoms", content)
+
+    def test_no_download_for_finished_job(self):
+        """Finished job → no error file downloaded."""
+        sub = self._make_submission([JobStatus.finished])
+        sub.try_download_error_info()
+
+        local_err_path = os.path.join(self._tmpdir, "hash_0000_last_err_file")
+        self.assertFalse(os.path.exists(local_err_path))
+
+    def test_no_error_file_on_remote(self):
+        """Terminated job but no error file on remote → graceful no-op."""
+        sub = self._make_submission(
+            [JobStatus.terminated],
+            err_file_exists=False,
+        )
+        # Should not raise
+        sub.try_download_error_info()
+
+        local_err_path = os.path.join(self._tmpdir, "hash_0000_last_err_file")
+        self.assertFalse(os.path.exists(local_err_path))
+
+    def test_multiple_jobs_mixed_states(self):
+        """Mixed finished/terminated → only download for failed ones."""
+        sub = self._make_submission(
+            [JobStatus.finished, JobStatus.terminated, JobStatus.finished],
+            err_content="segfault",
+        )
+        sub.try_download_error_info()
+
+        # Only job 1 (terminated) should have error file
+        self.assertFalse(os.path.exists(
+            os.path.join(self._tmpdir, "hash_0000_last_err_file")
+        ))
+        self.assertTrue(os.path.exists(
+            os.path.join(self._tmpdir, "hash_0001_last_err_file")
+        ))
+        self.assertFalse(os.path.exists(
+            os.path.join(self._tmpdir, "hash_0002_last_err_file")
+        ))
+
+    def test_context_exception_does_not_crash(self):
+        """If context raises during error download, it's caught gracefully."""
+        sub = self._make_submission([JobStatus.terminated])
+        sub.machine.context.check_file_exists = MagicMock(side_effect=OSError("network error"))
+
+        # Should not raise
+        sub.try_download_error_info()
+
+    def test_no_machine_is_noop(self):
+        """If machine is None, try_download_error_info is a no-op."""
+        submission = Submission.__new__(Submission)
+        submission.machine = None
+        submission.belonging_jobs = []
+        # Should not raise
+        submission.try_download_error_info()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_download_error_info.py
+++ b/tests/test_download_error_info.py
@@ -27,14 +27,10 @@ class TestDownloadErrorInfo(unittest.TestCase):
         self._tmpdir = tempfile.mkdtemp()
         submission.machine.context.local_root = self._tmpdir
 
-        def mock_check_file_exists(fname):
-            return err_file_exists
+        def mock_get_job_error(job):
+            return err_content if err_file_exists else None
 
-        def mock_read_file(fname):
-            return err_content
-
-        submission.machine.context.check_file_exists = mock_check_file_exists
-        submission.machine.context.read_file = mock_read_file
+        submission.machine.get_job_error = MagicMock(side_effect=mock_get_job_error)
 
         for i, state in enumerate(job_states):
             job = MagicMock()
@@ -106,9 +102,7 @@ class TestDownloadErrorInfo(unittest.TestCase):
     def test_context_exception_does_not_crash(self):
         """If context raises during error download, it's caught gracefully."""
         sub = self._make_submission([JobStatus.terminated])
-        sub.machine.context.check_file_exists = MagicMock(
-            side_effect=OSError("network error")
-        )
+        sub.machine.get_job_error = MagicMock(side_effect=OSError("network error"))
 
         # Should not raise
         sub.try_download_error_info()
@@ -151,8 +145,7 @@ class TestDownloadErrorInfoOnExhaustedRetries(unittest.TestCase):
         sub.machine = MagicMock()
         sub.machine.context.local_root = self._tmpdir
         sub.machine.context.remote_root = "/tmp/fake_remote"
-        sub.machine.context.check_file_exists = MagicMock(return_value=True)
-        sub.machine.context.read_file = MagicMock(return_value=err_content)
+        sub.machine.get_job_error = MagicMock(return_value=err_content)
 
         # Submission attributes
         sub.submission_hash = "test_hash_exhausted"

--- a/tests/test_download_error_info.py
+++ b/tests/test_download_error_info.py
@@ -265,6 +265,35 @@ class TestDownloadErrorInfoOnExhaustedRetries(unittest.TestCase):
         with open(local_err_path) as f:
             self.assertIn("MPI_ABORT called", f.read())
 
+    def test_recovered_terminated_job_downloads_error_before_reraise(self):
+        """The first failure-handling call is inside the diagnostic guard."""
+        sub = self._make_submission_for_run(err_content="recovered job stderr")
+
+        sub.generate_jobs = MagicMock()
+        sub.try_recover_from_json = MagicMock()
+        sub.update_submission_state = MagicMock()
+        sub.submission_to_json = MagicMock()
+        sub.upload_jobs = MagicMock()
+        sub.serialize = MagicMock(return_value={})
+        sub.try_download_result = MagicMock()
+        sub.check_all_finished = MagicMock(return_value=False)
+
+        with self.assertRaises(RuntimeError):
+            sub.run_submission(check_interval=0, clean=False)
+
+        sub.try_recover_from_json.assert_called_once()
+        sub.upload_jobs.assert_called_once()
+        sub.try_download_result.assert_not_called()
+        local_err_path = os.path.join(
+            self._tmpdir, "hash_retry_exhausted_last_err_file"
+        )
+        self.assertTrue(
+            os.path.exists(local_err_path),
+            "Recovered-job diagnostics were not downloaded before re-raising.",
+        )
+        with open(local_err_path) as f:
+            self.assertIn("recovered job stderr", f.read())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_download_error_info.py
+++ b/tests/test_download_error_info.py
@@ -4,7 +4,7 @@ import os
 import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -120,6 +120,150 @@ class TestDownloadErrorInfo(unittest.TestCase):
         submission.belonging_jobs = []
         # Should not raise
         submission.try_download_error_info()
+
+
+class TestDownloadErrorInfoOnExhaustedRetries(unittest.TestCase):
+    """Integration test: error files are downloaded even when retries are exhausted.
+
+    When handle_unexpected_submission_state() raises RuntimeError (because a job
+    exhausted its retry limit), the try/finally in run_submission() must still
+    call try_download_error_info() before propagating the exception.
+    """
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+
+        if os.path.exists(self._tmpdir):
+            shutil.rmtree(self._tmpdir)
+
+    def _make_submission_for_run(self, err_content="FATAL: out of memory"):
+        """Build a Submission wired to simulate exhausted retries in run_submission."""
+        sub = Submission.__new__(Submission)
+
+        # Resources with strategy
+        sub.resources = MagicMock()
+        sub.resources.strategy = {"ratio_unfinished": 0.0}
+
+        # Machine/context mocks
+        sub.machine = MagicMock()
+        sub.machine.context.local_root = self._tmpdir
+        sub.machine.context.remote_root = "/tmp/fake_remote"
+        sub.machine.context.check_file_exists = MagicMock(return_value=True)
+        sub.machine.context.read_file = MagicMock(return_value=err_content)
+
+        # Submission attributes
+        sub.submission_hash = "test_hash_exhausted"
+
+        # Create a terminated job
+        job = MagicMock()
+        job.job_state = JobStatus.terminated
+        job.job_hash = "hash_retry_exhausted"
+        # Make handle_unexpected_job_state raise to simulate exhausted retries
+        job.handle_unexpected_job_state.side_effect = RuntimeError(
+            "Job exceeded maximum retries"
+        )
+        sub.belonging_jobs = [job]
+
+        return sub
+
+    @patch("dpdispatcher.submission.record")
+    def test_error_file_downloaded_when_retries_exhausted(self, mock_record):
+        """run_submission raises RuntimeError but error file is still written."""
+        mock_record.write.return_value = "/tmp/fake_record.json"
+
+        sub = self._make_submission_for_run(err_content="SEGFAULT in lammps")
+
+        # Patch methods that run before the failure point
+        sub.generate_jobs = MagicMock()
+        sub.try_recover_from_json = MagicMock()
+        sub.update_submission_state = MagicMock()
+        sub.submission_to_json = MagicMock()
+        sub.upload_jobs = MagicMock()
+        sub.serialize = MagicMock(return_value={})
+        sub.try_download_result = MagicMock()
+
+        # check_all_finished: first call returns True (skips else branch),
+        # then returns False (enters while loop), then True (exits loop).
+        # The second handle_unexpected_submission_state (after while) will raise.
+        call_count = {"n": 0}
+
+        def fake_check_all_finished():
+            call_count["n"] += 1
+            # 1st call (initial check): True → skip else branch
+            if call_count["n"] == 1:
+                return True
+            # 2nd call (while condition): False → enter loop body not needed,
+            # actually we want to exit loop immediately so handle_unexpected fires
+            return True
+
+        sub.check_all_finished = fake_check_all_finished
+
+        # The RuntimeError should propagate from handle_unexpected_submission_state
+        with self.assertRaises(RuntimeError) as ctx:
+            sub.run_submission(check_interval=0, clean=False)
+
+        self.assertIn("unexpected submission state", str(ctx.exception).lower())
+
+        # Despite the RuntimeError, the error file must have been downloaded
+        local_err_path = os.path.join(
+            self._tmpdir, "hash_retry_exhausted_last_err_file"
+        )
+        self.assertTrue(
+            os.path.exists(local_err_path),
+            f"Error file not found at {local_err_path}; "
+            "try_download_error_info was not called on the failure path.",
+        )
+        with open(local_err_path) as f:
+            content = f.read()
+        self.assertIn("SEGFAULT in lammps", content)
+
+    @patch("dpdispatcher.submission.record")
+    def test_error_file_downloaded_when_retries_exhausted_in_loop(self, mock_record):
+        """Error in handle_unexpected inside the while-loop still downloads error file."""
+        mock_record.write.return_value = "/tmp/fake_record.json"
+
+        sub = self._make_submission_for_run(err_content="MPI_ABORT called")
+
+        sub.generate_jobs = MagicMock()
+        sub.try_recover_from_json = MagicMock()
+        sub.update_submission_state = MagicMock()
+        sub.submission_to_json = MagicMock()
+        sub.upload_jobs = MagicMock()
+        sub.serialize = MagicMock(return_value={})
+        sub.try_download_result = MagicMock()
+
+        call_count = {"n": 0}
+
+        def fake_check_all_finished():
+            call_count["n"] += 1
+            # 1st: initial check → True (skip else branch)
+            if call_count["n"] == 1:
+                return True
+            # 2nd: while condition → False (enter loop)
+            if call_count["n"] == 2:
+                return False
+            # Should not reach here since handle_unexpected raises in the loop
+            return True
+
+        sub.check_all_finished = fake_check_all_finished
+
+        with self.assertRaises(RuntimeError):
+            sub.run_submission(check_interval=0, clean=False)
+
+        # Error file must still be present
+        local_err_path = os.path.join(
+            self._tmpdir, "hash_retry_exhausted_last_err_file"
+        )
+        self.assertTrue(
+            os.path.exists(local_err_path),
+            "try_download_error_info was not called when handle_unexpected "
+            "raised inside the while-loop.",
+        )
+        with open(local_err_path) as f:
+            self.assertIn("MPI_ABORT called", f.read())
 
 
 if __name__ == "__main__":

--- a/tests/test_download_error_info.py
+++ b/tests/test_download_error_info.py
@@ -186,8 +186,8 @@ class TestDownloadErrorInfoOnExhaustedRetries(unittest.TestCase):
         sub.try_download_result = MagicMock()
 
         # check_all_finished: first call returns True (skips else branch),
-        # then returns False (enters while loop), then True (exits loop).
-        # The second handle_unexpected_submission_state (after while) will raise.
+        # every later call also returns True so the while loop exits immediately.
+        # handle_unexpected_submission_state() after the loop then raises.
         call_count = {"n": 0}
 
         def fake_check_all_finished():
@@ -195,8 +195,8 @@ class TestDownloadErrorInfoOnExhaustedRetries(unittest.TestCase):
             # 1st call (initial check): True → skip else branch
             if call_count["n"] == 1:
                 return True
-            # 2nd call (while condition): False → enter loop body not needed,
-            # actually we want to exit loop immediately so handle_unexpected fires
+            # while condition: True → exit loop immediately,
+            # then handle_unexpected_submission_state() fires
             return True
 
         sub.check_all_finished = fake_check_all_finished


### PR DESCRIPTION
## Problem

When a job fails (terminated), the `_last_err_file` containing the last 1000 bytes of stderr exists on the remote workdir but is never downloaded to local. After `clean_jobs()` runs, this diagnostic info is permanently lost.

The existing `get_last_error_message()` method only reads error info during the run (in retry logic), but does not persist it locally.

## Solution

Add `try_download_error_info()` method called in `run_submission()` after `try_download_result()` and before `clean_jobs()`:

1. For each non-finished job, check if `{job_hash}_last_err_file` exists on remote
2. Download content to `local_root/{job_hash}_last_err_file`
3. Log the error content as WARNING for immediate visibility
4. Gracefully handle missing files and context exceptions

This ensures error diagnostics survive remote workdir cleanup.

## Tests

6 unit tests in `test_download_error_info.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error diagnostics are now retrieved even when submission processing encounters unexpected failures or retry exhaustion.
  * Diagnostic download failures no longer mask the original submission error.
  * Downloaded diagnostics are logged and retained locally for unfinished jobs, improving troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->