### PR TITLE
fix: re-upload forward files before retry on terminated jobs

### DIFF
--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -93,7 +93,10 @@ class LocalContext(BaseContext):
                 f"cannot find uploaded file {os.path.join(local_path)}"
             )
         if os.path.exists(remote_path):
-            os.remove(remote_path)
+            if os.path.isdir(remote_path):
+                shutil.rmtree(remote_path)
+            else:
+                os.remove(remote_path)
         _check_file_path(remote_path)
 
         if self.symlink:

--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -92,8 +92,8 @@ class LocalContext(BaseContext):
             raise FileNotFoundError(
                 f"cannot find uploaded file {os.path.join(local_path)}"
             )
-        if os.path.exists(remote_path):
-            if os.path.isdir(remote_path):
+        if os.path.lexists(remote_path):
+            if os.path.isdir(remote_path) and not os.path.islink(remote_path):
                 shutil.rmtree(remote_path)
             else:
                 os.remove(remote_path)

--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -109,6 +109,22 @@ class LocalContext(BaseContext):
         else:
             raise ValueError(f"Unknown file type: {local_path}")
 
+    def _copy_missing_from_local_to_remote(self, local_path, remote_path):
+        """Copy missing paths without replacing an existing remote entry."""
+        if os.path.lexists(remote_path):
+            if (
+                os.path.isdir(local_path)
+                and os.path.isdir(remote_path)
+                and not os.path.islink(remote_path)
+            ):
+                for name in os.listdir(local_path):
+                    self._copy_missing_from_local_to_remote(
+                        os.path.join(local_path, name),
+                        os.path.join(remote_path, name),
+                    )
+            return
+        self._copy_from_local_to_remote(local_path, remote_path)
+
     def upload(self, submission):
         os.makedirs(self.remote_root, exist_ok=True)
         for ii in submission.belonging_tasks:
@@ -149,9 +165,12 @@ class LocalContext(BaseContext):
             file_list.extend(rel_file_list)
 
         for jj in file_list:
-            self._copy_from_local_to_remote(
-                os.path.join(local_job, jj), os.path.join(remote_job, jj)
-            )
+            local_path = os.path.join(local_job, jj)
+            remote_path = os.path.join(remote_job, jj)
+            if getattr(submission, "preserve_existing_forward_common_files", False):
+                self._copy_missing_from_local_to_remote(local_path, remote_path)
+            else:
+                self._copy_from_local_to_remote(local_path, remote_path)
 
     def download(
         self, submission, check_exists=False, mark_failure=True, back_error=False

--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess as sp
+import tempfile
 from glob import glob
 from subprocess import TimeoutExpired
 from typing import List
@@ -109,7 +110,9 @@ class LocalContext(BaseContext):
         else:
             raise ValueError(f"Unknown file type: {local_path}")
 
-    def _copy_missing_from_local_to_remote(self, local_path, remote_path):
+    def _copy_missing_from_local_to_remote(
+        self, local_path: str, remote_path: str
+    ) -> None:
         """Copy missing paths without replacing an existing remote entry."""
         if os.path.lexists(remote_path):
             if (
@@ -123,7 +126,48 @@ class LocalContext(BaseContext):
                         os.path.join(remote_path, name),
                     )
             return
-        self._copy_from_local_to_remote(local_path, remote_path)
+        if not os.path.exists(local_path):
+            raise FileNotFoundError(
+                f"cannot find uploaded file {os.path.join(local_path)}"
+            )
+
+        _check_file_path(remote_path)
+        if self.symlink:
+            try:
+                os.symlink(local_path, remote_path)
+            except FileExistsError:
+                pass
+            return
+
+        remote_dir = os.path.dirname(remote_path) or "."
+        if os.path.isfile(local_path):
+            descriptor, staged_path = tempfile.mkstemp(
+                prefix=".dpdispatcher-", dir=remote_dir
+            )
+            os.close(descriptor)
+            try:
+                shutil.copyfile(local_path, staged_path)
+                try:
+                    os.link(staged_path, remote_path)
+                except FileExistsError:
+                    pass
+            finally:
+                if os.path.exists(staged_path):
+                    os.remove(staged_path)
+        elif os.path.isdir(local_path):
+            stage_root = tempfile.mkdtemp(prefix=".dpdispatcher-", dir=remote_dir)
+            staged_path = os.path.join(stage_root, "payload")
+            try:
+                shutil.copytree(local_path, staged_path)
+                try:
+                    os.rename(staged_path, remote_path)
+                except OSError:
+                    if not os.path.lexists(remote_path):
+                        raise
+            finally:
+                shutil.rmtree(stage_root, ignore_errors=True)
+        else:
+            raise ValueError(f"Unknown file type: {local_path}")
 
     def upload(self, submission):
         os.makedirs(self.remote_root, exist_ok=True)

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1018,7 +1018,8 @@ class Job:
         # context.upload() expects .belonging_tasks and .forward_common_files.
 
         class _RetryPayload:
-            pass
+            belonging_tasks: List
+            forward_common_files: List
 
         payload = _RetryPayload()
         payload.belonging_tasks = self.job_task_list

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1009,9 +1009,7 @@ class Job:
                 if not context.check_file_exists(fwd):
                     local_file = os.path.join(local_job, fwd)
                     if os.path.exists(local_file):
-                        dlog.info(
-                            f"re-uploading missing forward file on retry: {fwd}"
-                        )
+                        dlog.info(f"re-uploading missing forward file on retry: {fwd}")
                         os.makedirs(os.path.dirname(remote_file), exist_ok=True)
                         context._copy_from_local_to_remote(local_file, remote_file)
                     else:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1048,9 +1048,9 @@ class Job:
         rel_prefix : str
             Prefix for constructing paths relative to remote_root.
         """
-        from glob import glob
         import shlex
         import shutil
+        from glob import glob
 
         for pattern in file_patterns:
             # Expand glob patterns
@@ -1066,7 +1066,9 @@ class Job:
             for local_file in matched_files:
                 rel_file = os.path.relpath(local_file, start=local_base)
                 # check_file_exists expects path relative to remote_root
-                check_path = os.path.join(rel_prefix, rel_file) if rel_prefix else rel_file
+                check_path = (
+                    os.path.join(rel_prefix, rel_file) if rel_prefix else rel_file
+                )
                 if not context.check_file_exists(check_path):
                     remote_file = os.path.join(remote_base, rel_file)
                     dlog.info(
@@ -1083,9 +1085,7 @@ class Job:
                             start=context.remote_root,
                         )
                         if remote_dir and remote_dir != ".":
-                            context.block_call(
-                                f"mkdir -p {shlex.quote(remote_dir)}"
-                            )
+                            context.block_call(f"mkdir -p {shlex.quote(remote_dir)}")
                         # Binary-safe: read as bytes, use shutil for local or
                         # sftp put for SSH (write_file is text-only)
                         if hasattr(context, "sftp"):

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1006,15 +1006,23 @@ class Job:
             local_job = os.path.join(context.local_root, task.task_work_path)
             for fwd in task.forward_files:
                 remote_file = os.path.join(remote_job, fwd)
-                if not context.check_file_exists(fwd):
+                # check_file_exists expects path relative to remote_root
+                relative_path = os.path.join(task.task_work_path, fwd)
+                # Use os.path.exists for the absolute path since check_file_exists
+                # only tests isfile (misses directories)
+                if not os.path.exists(remote_file):
                     local_file = os.path.join(local_job, fwd)
                     if os.path.exists(local_file):
-                        dlog.info(f"re-uploading missing forward file on retry: {fwd}")
+                        dlog.info(
+                            f"re-uploading missing forward file on retry: "
+                            f"{relative_path}"
+                        )
                         os.makedirs(os.path.dirname(remote_file), exist_ok=True)
                         context._copy_from_local_to_remote(local_file, remote_file)
                     else:
                         dlog.warning(
-                            f"forward file missing both locally and remotely: {fwd}"
+                            f"forward file missing both locally and remotely: "
+                            f"{relative_path}"
                         )
 
 

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -904,7 +904,13 @@ class Job:
                 raise RuntimeError(err_msg)
             # Re-upload forward files before retry to handle cases where remote
             # workdir was cleaned or files were removed between attempts.
-            self._ensure_forward_files_on_retry()
+            try:
+                self._ensure_forward_files_on_retry()
+            except Exception as e:
+                dlog.warning(
+                    f"job {self.job_hash} failed to restore forward files "
+                    f"before retry: {e}"
+                )
             self.submit_job()
             if self.job_state != JobStatus.unsubmitted:
                 dlog.info(
@@ -991,110 +997,33 @@ class Job:
             return last_error_message
 
     def _ensure_forward_files_on_retry(self) -> None:
-        """Re-upload forward files if they are missing on remote before retry.
+        """Re-upload forward files before retry by delegating to context.upload().
 
-        When a job is retried after termination, the forward files may have been
-        removed (e.g., by clean, NFS race, or a previous failed attempt). This
-        method checks each forward file (both per-task and common) on the remote
-        workdir and re-uploads from local if missing.
+        When a job is retried after termination, forward files may have been
+        removed from the remote workdir. This method re-uploads them using the
+        same upload mechanism as the initial submission, which correctly handles
+        all context types (Local, SSH, HDFS, etc.), glob patterns, binary files,
+        and directory creation.
 
-        Handles both regular files and glob patterns in forward_files lists.
-        Uses binary-safe copy to avoid corrupting model weights (.pb, .pt, .npy).
+        Uses context.submission (set during bind_machine) to access both per-task
+        forward_files and forward_common_files.
         """
         if self.machine is None:
             return
         context = self.machine.context
+        submission = getattr(context, "submission", None)
+        if submission is None:
+            return
+        # Build a lightweight object with only this job's tasks for upload.
+        # context.upload() expects .belonging_tasks and .forward_common_files.
 
-        # Re-upload per-task forward files
-        for task in self.job_task_list:
-            remote_job = os.path.join(context.remote_root, task.task_work_path)
-            local_job = os.path.join(context.local_root, task.task_work_path)
-            self._reupload_files(
-                context, task.forward_files, local_job, remote_job, task.task_work_path
-            )
+        class _RetryPayload:
+            pass
 
-        # Re-upload forward_common_files (shared across tasks, at remote_root level)
-        submission = self._get_submission()
-        if submission is not None and submission.forward_common_files:
-            self._reupload_files(
-                context,
-                submission.forward_common_files,
-                context.local_root,
-                context.remote_root,
-                "",
-            )
-
-    def _get_submission(self):
-        """Get the parent Submission object if available."""
-        # Walk up: Job is in Submission.belonging_jobs
-        # This is set during bind_machine / generate_jobs
-        # If not accessible, return None (forward_common_files won't be re-uploaded)
-        return getattr(self, "_submission", None)
-
-    @staticmethod
-    def _reupload_files(context, file_patterns, local_base, remote_base, rel_prefix):
-        """Re-upload missing files matching the given patterns.
-
-        Parameters
-        ----------
-        context : BaseContext
-            The context object for file operations.
-        file_patterns : list
-            List of file paths or glob patterns.
-        local_base : str
-            Local base directory containing the files.
-        remote_base : str
-            Remote base directory where files should exist.
-        rel_prefix : str
-            Prefix for constructing paths relative to remote_root.
-        """
-        from glob import glob
-        import shlex
-        import shutil
-
-        for pattern in file_patterns:
-            # Expand glob patterns
-            matched_files = glob(os.path.join(local_base, pattern))
-            if not matched_files:
-                # Pattern didn't match — check as literal path
-                literal = os.path.join(local_base, pattern)
-                if os.path.exists(literal):
-                    matched_files = [literal]
-                else:
-                    continue
-
-            for local_file in matched_files:
-                rel_file = os.path.relpath(local_file, start=local_base)
-                # check_file_exists expects path relative to remote_root
-                check_path = os.path.join(rel_prefix, rel_file) if rel_prefix else rel_file
-                if not context.check_file_exists(check_path):
-                    remote_file = os.path.join(remote_base, rel_file)
-                    dlog.info(
-                        f"re-uploading missing forward file on retry: {check_path}"
-                    )
-                    if hasattr(context, "_copy_from_local_to_remote"):
-                        # LocalContext: create parent dirs + binary-safe copy
-                        os.makedirs(os.path.dirname(remote_file), exist_ok=True)
-                        context._copy_from_local_to_remote(local_file, remote_file)
-                    else:
-                        # Non-local contexts: mkdir via shell + binary copy
-                        remote_dir = os.path.relpath(
-                            os.path.dirname(remote_file),
-                            start=context.remote_root,
-                        )
-                        if remote_dir and remote_dir != ".":
-                            context.block_call(
-                                f"mkdir -p {shlex.quote(remote_dir)}"
-                            )
-                        # Binary-safe: read as bytes, use shutil for local or
-                        # sftp put for SSH (write_file is text-only)
-                        if hasattr(context, "sftp"):
-                            # SSHContext: use sftp.put for binary safety
-                            context.ssh_session.ensure_alive()
-                            context.sftp.put(local_file, remote_file)
-                        else:
-                            # Fallback: direct binary copy (works for local-like contexts)
-                            shutil.copy2(local_file, remote_file)
+        payload = _RetryPayload()
+        payload.belonging_tasks = self.job_task_list
+        payload.forward_common_files = submission.forward_common_files
+        context.upload(payload)
 
 
 class Resources:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -990,13 +990,17 @@ class Job:
             last_error_message = "\033[31m" + last_error_message + "\033[0m"
             return last_error_message
 
-    def _ensure_forward_files_on_retry(self):
+    def _ensure_forward_files_on_retry(self) -> None:
         """Re-upload forward files if they are missing on remote before retry.
 
         When a job is retried after termination, the forward files may have been
         removed (e.g., by clean, NFS race, or a previous failed attempt). This
         method checks if the key forward files exist on the remote workdir and
         re-uploads them if missing.
+
+        Note: Uses context.check_file_exists() for cross-context compatibility,
+        and the context's own copy mechanism for re-upload. For contexts without
+        a single-file upload method (e.g., SSHContext), logs a warning and skips.
         """
         if self.machine is None:
             return
@@ -1005,20 +1009,37 @@ class Job:
             remote_job = os.path.join(context.remote_root, task.task_work_path)
             local_job = os.path.join(context.local_root, task.task_work_path)
             for fwd in task.forward_files:
-                remote_file = os.path.join(remote_job, fwd)
-                # check_file_exists expects path relative to remote_root
+                # check_file_exists takes a path relative to remote_root
                 relative_path = os.path.join(task.task_work_path, fwd)
-                # Use os.path.exists for the absolute path since check_file_exists
-                # only tests isfile (misses directories)
-                if not os.path.exists(remote_file):
+                if not context.check_file_exists(relative_path):
                     local_file = os.path.join(local_job, fwd)
                     if os.path.exists(local_file):
                         dlog.info(
                             f"re-uploading missing forward file on retry: "
                             f"{relative_path}"
                         )
-                        os.makedirs(os.path.dirname(remote_file), exist_ok=True)
-                        context._copy_from_local_to_remote(local_file, remote_file)
+                        remote_file = os.path.join(remote_job, fwd)
+                        if hasattr(context, "_copy_from_local_to_remote"):
+                            # LocalContext: create parent dirs + copy
+                            os.makedirs(
+                                os.path.dirname(remote_file), exist_ok=True
+                            )
+                            context._copy_from_local_to_remote(
+                                local_file, remote_file
+                            )
+                        else:
+                            # Non-local contexts (SSH, etc.): mkdir via shell,
+                            # then write file content through the context
+                            remote_dir = os.path.relpath(
+                                os.path.dirname(remote_file),
+                                start=context.remote_root,
+                            )
+                            if remote_dir and remote_dir != ".":
+                                context.block_call(f"mkdir -p {remote_dir}")
+                            # Read and write via context's write_file
+                            with open(local_file, "r") as f:
+                                content = f.read()
+                            context.write_file(relative_path, content)
                     else:
                         dlog.warning(
                             f"forward file missing both locally and remotely: "

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -995,56 +995,106 @@ class Job:
 
         When a job is retried after termination, the forward files may have been
         removed (e.g., by clean, NFS race, or a previous failed attempt). This
-        method checks if the key forward files exist on the remote workdir and
-        re-uploads them if missing.
+        method checks each forward file (both per-task and common) on the remote
+        workdir and re-uploads from local if missing.
 
-        Note: Uses context.check_file_exists() for cross-context compatibility,
-        and the context's own copy mechanism for re-upload. For contexts without
-        a single-file upload method (e.g., SSHContext), logs a warning and skips.
+        Handles both regular files and glob patterns in forward_files lists.
+        Uses binary-safe copy to avoid corrupting model weights (.pb, .pt, .npy).
         """
         if self.machine is None:
             return
         context = self.machine.context
+
+        # Re-upload per-task forward files
         for task in self.job_task_list:
             remote_job = os.path.join(context.remote_root, task.task_work_path)
             local_job = os.path.join(context.local_root, task.task_work_path)
-            for fwd in task.forward_files:
-                # check_file_exists takes a path relative to remote_root
-                relative_path = os.path.join(task.task_work_path, fwd)
-                if not context.check_file_exists(relative_path):
-                    local_file = os.path.join(local_job, fwd)
-                    if os.path.exists(local_file):
-                        dlog.info(
-                            f"re-uploading missing forward file on retry: "
-                            f"{relative_path}"
-                        )
-                        remote_file = os.path.join(remote_job, fwd)
-                        if hasattr(context, "_copy_from_local_to_remote"):
-                            # LocalContext: create parent dirs + copy
-                            os.makedirs(
-                                os.path.dirname(remote_file), exist_ok=True
-                            )
-                            context._copy_from_local_to_remote(
-                                local_file, remote_file
-                            )
-                        else:
-                            # Non-local contexts (SSH, etc.): mkdir via shell,
-                            # then write file content through the context
-                            remote_dir = os.path.relpath(
-                                os.path.dirname(remote_file),
-                                start=context.remote_root,
-                            )
-                            if remote_dir and remote_dir != ".":
-                                context.block_call(f"mkdir -p {remote_dir}")
-                            # Read and write via context's write_file
-                            with open(local_file, "r") as f:
-                                content = f.read()
-                            context.write_file(relative_path, content)
+            self._reupload_files(
+                context, task.forward_files, local_job, remote_job, task.task_work_path
+            )
+
+        # Re-upload forward_common_files (shared across tasks, at remote_root level)
+        submission = self._get_submission()
+        if submission is not None and submission.forward_common_files:
+            self._reupload_files(
+                context,
+                submission.forward_common_files,
+                context.local_root,
+                context.remote_root,
+                "",
+            )
+
+    def _get_submission(self):
+        """Get the parent Submission object if available."""
+        # Walk up: Job is in Submission.belonging_jobs
+        # This is set during bind_machine / generate_jobs
+        # If not accessible, return None (forward_common_files won't be re-uploaded)
+        return getattr(self, "_submission", None)
+
+    @staticmethod
+    def _reupload_files(context, file_patterns, local_base, remote_base, rel_prefix):
+        """Re-upload missing files matching the given patterns.
+
+        Parameters
+        ----------
+        context : BaseContext
+            The context object for file operations.
+        file_patterns : list
+            List of file paths or glob patterns.
+        local_base : str
+            Local base directory containing the files.
+        remote_base : str
+            Remote base directory where files should exist.
+        rel_prefix : str
+            Prefix for constructing paths relative to remote_root.
+        """
+        from glob import glob
+        import shlex
+        import shutil
+
+        for pattern in file_patterns:
+            # Expand glob patterns
+            matched_files = glob(os.path.join(local_base, pattern))
+            if not matched_files:
+                # Pattern didn't match — check as literal path
+                literal = os.path.join(local_base, pattern)
+                if os.path.exists(literal):
+                    matched_files = [literal]
+                else:
+                    continue
+
+            for local_file in matched_files:
+                rel_file = os.path.relpath(local_file, start=local_base)
+                # check_file_exists expects path relative to remote_root
+                check_path = os.path.join(rel_prefix, rel_file) if rel_prefix else rel_file
+                if not context.check_file_exists(check_path):
+                    remote_file = os.path.join(remote_base, rel_file)
+                    dlog.info(
+                        f"re-uploading missing forward file on retry: {check_path}"
+                    )
+                    if hasattr(context, "_copy_from_local_to_remote"):
+                        # LocalContext: create parent dirs + binary-safe copy
+                        os.makedirs(os.path.dirname(remote_file), exist_ok=True)
+                        context._copy_from_local_to_remote(local_file, remote_file)
                     else:
-                        dlog.warning(
-                            f"forward file missing both locally and remotely: "
-                            f"{relative_path}"
+                        # Non-local contexts: mkdir via shell + binary copy
+                        remote_dir = os.path.relpath(
+                            os.path.dirname(remote_file),
+                            start=context.remote_root,
                         )
+                        if remote_dir and remote_dir != ".":
+                            context.block_call(
+                                f"mkdir -p {shlex.quote(remote_dir)}"
+                            )
+                        # Binary-safe: read as bytes, use shutil for local or
+                        # sftp put for SSH (write_file is text-only)
+                        if hasattr(context, "sftp"):
+                            # SSHContext: use sftp.put for binary safety
+                            context.ssh_session.ensure_alive()
+                            context.sftp.put(local_file, remote_file)
+                        else:
+                            # Fallback: direct binary copy (works for local-like contexts)
+                            shutil.copy2(local_file, remote_file)
 
 
 class Resources:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1021,12 +1021,8 @@ class Job:
                         remote_file = os.path.join(remote_job, fwd)
                         if hasattr(context, "_copy_from_local_to_remote"):
                             # LocalContext: create parent dirs + copy
-                            os.makedirs(
-                                os.path.dirname(remote_file), exist_ok=True
-                            )
-                            context._copy_from_local_to_remote(
-                                local_file, remote_file
-                            )
+                            os.makedirs(os.path.dirname(remote_file), exist_ok=True)
+                            context._copy_from_local_to_remote(local_file, remote_file)
                         else:
                             # Non-local contexts (SSH, etc.): mkdir via shell,
                             # then write file content through the context
@@ -1037,7 +1033,7 @@ class Job:
                             if remote_dir and remote_dir != ".":
                                 context.block_call(f"mkdir -p {remote_dir}")
                             # Read and write via context's write_file
-                            with open(local_file, "r") as f:
+                            with open(local_file) as f:
                                 content = f.read()
                             context.write_file(relative_path, content)
                     else:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -902,6 +902,9 @@ class Job:
                 if last_error_message is not None:
                     err_msg += f"\nPossible remote error message: {last_error_message}"
                 raise RuntimeError(err_msg)
+            # Re-upload forward files before retry to handle cases where remote
+            # workdir was cleaned or files were removed between attempts.
+            self._ensure_forward_files_on_retry()
             self.submit_job()
             if self.job_state != JobStatus.unsubmitted:
                 dlog.info(
@@ -986,6 +989,35 @@ class Job:
             # red color
             last_error_message = "\033[31m" + last_error_message + "\033[0m"
             return last_error_message
+
+    def _ensure_forward_files_on_retry(self):
+        """Re-upload forward files if they are missing on remote before retry.
+
+        When a job is retried after termination, the forward files may have been
+        removed (e.g., by clean, NFS race, or a previous failed attempt). This
+        method checks if the key forward files exist on the remote workdir and
+        re-uploads them if missing.
+        """
+        if self.machine is None:
+            return
+        context = self.machine.context
+        for task in self.job_task_list:
+            remote_job = os.path.join(context.remote_root, task.task_work_path)
+            local_job = os.path.join(context.local_root, task.task_work_path)
+            for fwd in task.forward_files:
+                remote_file = os.path.join(remote_job, fwd)
+                if not context.check_file_exists(fwd):
+                    local_file = os.path.join(local_job, fwd)
+                    if os.path.exists(local_file):
+                        dlog.info(
+                            f"re-uploading missing forward file on retry: {fwd}"
+                        )
+                        os.makedirs(os.path.dirname(remote_file), exist_ok=True)
+                        context._copy_from_local_to_remote(local_file, remote_file)
+                    else:
+                        dlog.warning(
+                            f"forward file missing both locally and remotely: {fwd}"
+                        )
 
 
 class Resources:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -904,13 +904,10 @@ class Job:
                 raise RuntimeError(err_msg)
             # Re-upload forward files before retry to handle cases where remote
             # workdir was cleaned or files were removed between attempts.
-            try:
-                self._ensure_forward_files_on_retry()
-            except Exception as e:
-                dlog.warning(
-                    f"job {self.job_hash} failed to restore forward files "
-                    f"before retry: {e}"
-                )
+            # A failed restoration must stop the retry: submitting without the
+            # required inputs only hides the actionable staging error and causes
+            # another predictable job failure.
+            self._ensure_forward_files_on_retry()
             self.submit_job()
             if self.job_state != JobStatus.unsubmitted:
                 dlog.info(

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1019,10 +1019,12 @@ class Job:
 
         class _RetryPayload:
             belonging_tasks: List
+            belonging_jobs: List
             forward_common_files: List
 
         payload = _RetryPayload()
         payload.belonging_tasks = self.job_task_list
+        payload.belonging_jobs = [self]
         payload.forward_common_files = submission.forward_common_files
         context.upload(payload)
 

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1021,11 +1021,13 @@ class Job:
             belonging_tasks: List["Task"]
             belonging_jobs: List["Job"]
             forward_common_files: List[str]
+            preserve_existing_forward_common_files: bool
 
         payload = _RetryPayload()
         payload.belonging_tasks = self.job_task_list
         payload.belonging_jobs = [self]
         payload.forward_common_files = submission.forward_common_files
+        payload.preserve_existing_forward_common_files = True
         context.upload(payload)
 
 

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1018,9 +1018,9 @@ class Job:
         # context.upload() expects .belonging_tasks and .forward_common_files.
 
         class _RetryPayload:
-            belonging_tasks: List
-            belonging_jobs: List
-            forward_common_files: List
+            belonging_tasks: List["Task"]
+            belonging_jobs: List["Job"]
+            forward_common_files: List[str]
 
         payload = _RetryPayload()
         payload.belonging_tasks = self.job_task_list

--- a/tests/test_retry_common_files.py
+++ b/tests/test_retry_common_files.py
@@ -2,8 +2,10 @@
 
 import os
 import tempfile
+import threading
 import unittest
-from unittest.mock import MagicMock
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
 
 from dpdispatcher.contexts.local_context import LocalContext
 from dpdispatcher.submission import Job
@@ -29,7 +31,7 @@ class TestRetryCommonFiles(unittest.TestCase):
 
         job._ensure_forward_files_on_retry()
 
-        payload = context.upload.call_args.args[0]
+        payload = context.upload.call_args[0][0]
         self.assertTrue(payload.preserve_existing_forward_common_files)
 
     def test_existing_common_entries_are_preserved_while_missing_entries_are_added(
@@ -64,6 +66,51 @@ class TestRetryCommonFiles(unittest.TestCase):
                 self.assertEqual(fp.read(), "in use by sibling job")
             with open(os.path.join(remote_common, "config.json")) as fp:
                 self.assertEqual(fp.read(), "new config")
+
+    def test_concurrent_retries_publish_shared_directory_atomically(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_root = os.path.join(tmpdir, "local")
+            remote_root = os.path.join(tmpdir, "remote")
+            local_common = os.path.join(local_root, "shared")
+            remote_common = os.path.join(remote_root, "shared")
+            os.makedirs(local_common)
+            os.makedirs(remote_root)
+            with open(os.path.join(local_common, "model.pb"), "w") as fp:
+                fp.write("complete model")
+
+            context = LocalContext.__new__(LocalContext)
+            context.symlink = False
+            publish_barrier = threading.Barrier(2)
+            rename = os.rename
+
+            def synchronized_rename(source, target):
+                publish_barrier.wait(timeout=5)
+                return rename(source, target)
+
+            with patch(
+                "dpdispatcher.contexts.local_context.os.rename",
+                side_effect=synchronized_rename,
+            ):
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    futures = [
+                        executor.submit(
+                            context._copy_missing_from_local_to_remote,
+                            local_common,
+                            remote_common,
+                        )
+                        for _ in range(2)
+                    ]
+                    for future in futures:
+                        future.result()
+
+            with open(os.path.join(remote_common, "model.pb")) as fp:
+                self.assertEqual(fp.read(), "complete model")
+            self.assertFalse(
+                any(
+                    name.startswith(".dpdispatcher-")
+                    for name in os.listdir(remote_root)
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_retry_common_files.py
+++ b/tests/test_retry_common_files.py
@@ -1,0 +1,70 @@
+"""Regression tests for shared forward files during retry."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from dpdispatcher.contexts.local_context import LocalContext
+from dpdispatcher.submission import Job
+
+
+class TestRetryCommonFiles(unittest.TestCase):
+    """A single-job retry must not replace live shared inputs."""
+
+    def _make_job(self, context):
+        job = Job.__new__(Job)
+        job.machine = MagicMock()
+        job.machine.context = context
+        task = MagicMock()
+        task.task_work_path = "task0"
+        task.forward_files = []
+        job.job_task_list = [task]
+        return job
+
+    def test_retry_payload_requests_preservation(self):
+        context = MagicMock()
+        context.submission.forward_common_files = ["shared"]
+        job = self._make_job(context)
+
+        job._ensure_forward_files_on_retry()
+
+        payload = context.upload.call_args.args[0]
+        self.assertTrue(payload.preserve_existing_forward_common_files)
+
+    def test_existing_common_entries_are_preserved_while_missing_entries_are_added(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_root = os.path.join(tmpdir, "local")
+            remote_root = os.path.join(tmpdir, "remote")
+            local_common = os.path.join(local_root, "shared")
+            remote_common = os.path.join(remote_root, "shared")
+            os.makedirs(local_common)
+            os.makedirs(remote_common)
+
+            with open(os.path.join(local_common, "model.pb"), "w") as fp:
+                fp.write("replacement")
+            with open(os.path.join(local_common, "config.json"), "w") as fp:
+                fp.write("new config")
+            with open(os.path.join(remote_common, "model.pb"), "w") as fp:
+                fp.write("in use by sibling job")
+
+            context = LocalContext.__new__(LocalContext)
+            context.local_root = local_root
+            context.remote_root = remote_root
+            context.symlink = False
+            context.submission = MagicMock()
+            context.submission.forward_common_files = ["shared"]
+            job = self._make_job(context)
+
+            job._ensure_forward_files_on_retry()
+
+            with open(os.path.join(remote_common, "model.pb")) as fp:
+                self.assertEqual(fp.read(), "in use by sibling job")
+            with open(os.path.join(remote_common, "config.json")) as fp:
+                self.assertEqual(fp.read(), "new config")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retry_forward_directory.py
+++ b/tests/test_retry_forward_directory.py
@@ -1,0 +1,218 @@
+"""Regression test for PR #629 reviewer issue: retry upload with forwarded directories.
+
+Verifies that `_copy_from_local_to_remote` and `context.upload()` handle
+existing remote directories correctly without raising `IsADirectoryError`.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dpdispatcher.contexts.local_context import LocalContext
+from dpdispatcher.submission import Job
+
+
+class TestCopyFromLocalToRemoteDirectory(unittest.TestCase):
+    """Unit tests for _copy_from_local_to_remote with directory targets."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.local_root = os.path.join(self.tmpdir, "local")
+        self.remote_root = os.path.join(self.tmpdir, "remote")
+        os.makedirs(self.local_root)
+        os.makedirs(self.remote_root)
+
+        self.ctx = LocalContext.__new__(LocalContext)
+        self.ctx.local_root = self.local_root
+        self.ctx.remote_root = self.remote_root
+        self.ctx.symlink = False
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_replace_existing_directory(self):
+        """Existing remote directory is replaced without IsADirectoryError."""
+        # Create local directory with files
+        local_dir = os.path.join(self.local_root, "inputs")
+        os.makedirs(local_dir)
+        with open(os.path.join(local_dir, "data.txt"), "w") as f:
+            f.write("hello")
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write('{"key": "value"}')
+
+        # Create remote directory (simulating partial state — missing a file)
+        remote_dir = os.path.join(self.remote_root, "inputs")
+        os.makedirs(remote_dir)
+        with open(os.path.join(remote_dir, "data.txt"), "w") as f:
+            f.write("stale")
+        # config.json is missing on remote — this is the partial failure case
+
+        # Should NOT raise IsADirectoryError
+        self.ctx._copy_from_local_to_remote(local_dir, remote_dir)
+
+        # Verify the directory was fully re-uploaded
+        self.assertTrue(os.path.isdir(remote_dir))
+        self.assertTrue(os.path.exists(os.path.join(remote_dir, "data.txt")))
+        self.assertTrue(os.path.exists(os.path.join(remote_dir, "config.json")))
+        with open(os.path.join(remote_dir, "data.txt")) as f:
+            self.assertEqual(f.read(), "hello")
+        with open(os.path.join(remote_dir, "config.json")) as f:
+            self.assertEqual(f.read(), '{"key": "value"}')
+
+    def test_replace_existing_file(self):
+        """Existing remote file is still replaced correctly."""
+        local_file = os.path.join(self.local_root, "script.sh")
+        with open(local_file, "w") as f:
+            f.write("#!/bin/bash\necho new")
+
+        remote_file = os.path.join(self.remote_root, "script.sh")
+        with open(remote_file, "w") as f:
+            f.write("#!/bin/bash\necho old")
+
+        self.ctx._copy_from_local_to_remote(local_file, remote_file)
+
+        with open(remote_file) as f:
+            self.assertEqual(f.read(), "#!/bin/bash\necho new")
+
+    def test_copy_new_directory(self):
+        """Copying a directory when remote doesn't exist works normally."""
+        local_dir = os.path.join(self.local_root, "newdir")
+        os.makedirs(local_dir)
+        with open(os.path.join(local_dir, "file.txt"), "w") as f:
+            f.write("content")
+
+        remote_dir = os.path.join(self.remote_root, "newdir")
+
+        self.ctx._copy_from_local_to_remote(local_dir, remote_dir)
+
+        self.assertTrue(os.path.isdir(remote_dir))
+        with open(os.path.join(remote_dir, "file.txt")) as f:
+            self.assertEqual(f.read(), "content")
+
+    def test_nested_directory_replaced(self):
+        """Nested directory structure is fully replaced."""
+        local_dir = os.path.join(self.local_root, "inputs")
+        os.makedirs(os.path.join(local_dir, "subdir"))
+        with open(os.path.join(local_dir, "top.txt"), "w") as f:
+            f.write("top")
+        with open(os.path.join(local_dir, "subdir", "nested.txt"), "w") as f:
+            f.write("nested")
+
+        # Remote has partial content (missing subdir/nested.txt)
+        remote_dir = os.path.join(self.remote_root, "inputs")
+        os.makedirs(remote_dir)
+        with open(os.path.join(remote_dir, "top.txt"), "w") as f:
+            f.write("stale_top")
+
+        self.ctx._copy_from_local_to_remote(local_dir, remote_dir)
+
+        self.assertTrue(os.path.exists(os.path.join(remote_dir, "top.txt")))
+        self.assertTrue(os.path.exists(os.path.join(remote_dir, "subdir", "nested.txt")))
+        with open(os.path.join(remote_dir, "subdir", "nested.txt")) as f:
+            self.assertEqual(f.read(), "nested")
+
+
+class TestRetryUploadForwardDirectory(unittest.TestCase):
+    """Integration test: retry upload with a forwarded directory via context.upload()."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.local_root = os.path.join(self.tmpdir, "local")
+        self.remote_root = os.path.join(self.tmpdir, "remote")
+        os.makedirs(self.local_root)
+        os.makedirs(self.remote_root)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_retry_reupload_forward_directory_partial_remote(self):
+        """Retry upload successfully re-uploads a forward directory with partial remote state.
+
+        Regression test: previously os.remove() raised IsADirectoryError when the
+        remote destination was an existing directory.
+        """
+        ctx = LocalContext.__new__(LocalContext)
+        ctx.local_root = self.local_root
+        ctx.remote_root = self.remote_root
+        ctx.symlink = False
+        ctx.submission = MagicMock()
+        ctx.submission.forward_common_files = []
+
+        # Set up local task with a forward directory "inputs/"
+        local_task = os.path.join(self.local_root, "task0")
+        local_inputs = os.path.join(local_task, "inputs")
+        os.makedirs(local_inputs)
+        with open(os.path.join(local_inputs, "data.lammps"), "w") as f:
+            f.write("pair_style deepmd frozen.pb\n")
+        with open(os.path.join(local_inputs, "conf.lmp"), "w") as f:
+            f.write("# LAMMPS configuration\n")
+
+        # Simulate partial remote state: directory exists but a child is missing
+        remote_task = os.path.join(self.remote_root, "task0")
+        remote_inputs = os.path.join(remote_task, "inputs")
+        os.makedirs(remote_inputs)
+        with open(os.path.join(remote_inputs, "data.lammps"), "w") as f:
+            f.write("pair_style deepmd frozen.pb\n")
+        # conf.lmp is MISSING on remote — simulating the partial failure
+
+        # Build a Job and trigger retry upload
+        job = Job.__new__(Job)
+        job.machine = MagicMock()
+        job.machine.context = ctx
+
+        task = MagicMock()
+        task.task_work_path = "task0"
+        task.forward_files = ["inputs/"]
+        job.job_task_list = [task]
+
+        # This should NOT raise IsADirectoryError
+        job._ensure_forward_files_on_retry()
+
+        # Verify both files exist on remote after re-upload
+        self.assertTrue(os.path.exists(os.path.join(remote_inputs, "data.lammps")))
+        self.assertTrue(os.path.exists(os.path.join(remote_inputs, "conf.lmp")))
+        with open(os.path.join(remote_inputs, "conf.lmp")) as f:
+            self.assertEqual(f.read(), "# LAMMPS configuration\n")
+
+    def test_retry_reupload_forward_directory_no_existing_remote(self):
+        """Retry upload works when remote directory doesn't exist yet."""
+        ctx = LocalContext.__new__(LocalContext)
+        ctx.local_root = self.local_root
+        ctx.remote_root = self.remote_root
+        ctx.symlink = False
+        ctx.submission = MagicMock()
+        ctx.submission.forward_common_files = []
+
+        local_task = os.path.join(self.local_root, "task0")
+        local_inputs = os.path.join(local_task, "inputs")
+        os.makedirs(local_inputs)
+        with open(os.path.join(local_inputs, "file.txt"), "w") as f:
+            f.write("data")
+
+        # Remote task dir exists but inputs/ does not
+        remote_task = os.path.join(self.remote_root, "task0")
+        os.makedirs(remote_task)
+
+        job = Job.__new__(Job)
+        job.machine = MagicMock()
+        job.machine.context = ctx
+
+        task = MagicMock()
+        task.task_work_path = "task0"
+        task.forward_files = ["inputs/"]
+        job.job_task_list = [task]
+
+        job._ensure_forward_files_on_retry()
+
+        remote_inputs = os.path.join(remote_task, "inputs")
+        self.assertTrue(os.path.isdir(remote_inputs))
+        self.assertTrue(os.path.exists(os.path.join(remote_inputs, "file.txt")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retry_forward_directory.py
+++ b/tests/test_retry_forward_directory.py
@@ -118,6 +118,44 @@ class TestCopyFromLocalToRemoteDirectory(unittest.TestCase):
         with open(os.path.join(remote_dir, "subdir", "nested.txt")) as f:
             self.assertEqual(f.read(), "nested")
 
+    def test_replace_live_directory_symlink(self):
+        """The default symlink mode replaces an existing directory symlink."""
+        self.ctx.symlink = True
+        local_dir = os.path.join(self.local_root, "inputs")
+        os.makedirs(local_dir)
+        with open(os.path.join(local_dir, "new.txt"), "w") as f:
+            f.write("new")
+
+        old_target = os.path.join(self.tmpdir, "old-inputs")
+        os.makedirs(old_target)
+        remote_dir = os.path.join(self.remote_root, "inputs")
+        os.symlink(old_target, remote_dir)
+
+        self.ctx._copy_from_local_to_remote(local_dir, remote_dir)
+
+        self.assertTrue(os.path.islink(remote_dir))
+        self.assertEqual(os.path.realpath(remote_dir), os.path.realpath(local_dir))
+        self.assertTrue(os.path.exists(os.path.join(remote_dir, "new.txt")))
+
+    def test_replace_broken_symlink(self):
+        """A broken destination symlink is removed before retry upload."""
+        self.ctx.symlink = True
+        local_file = os.path.join(self.local_root, "input.txt")
+        with open(local_file, "w") as f:
+            f.write("new")
+
+        remote_file = os.path.join(self.remote_root, "input.txt")
+        os.symlink(os.path.join(self.tmpdir, "missing-target"), remote_file)
+        self.assertTrue(os.path.lexists(remote_file))
+        self.assertFalse(os.path.exists(remote_file))
+
+        self.ctx._copy_from_local_to_remote(local_file, remote_file)
+
+        self.assertTrue(os.path.islink(remote_file))
+        self.assertEqual(os.path.realpath(remote_file), os.path.realpath(local_file))
+        with open(remote_file) as f:
+            self.assertEqual(f.read(), "new")
+
 
 class TestRetryUploadForwardDirectory(unittest.TestCase):
     """Integration test: retry upload with a forwarded directory via context.upload()."""

--- a/tests/test_retry_forward_directory.py
+++ b/tests/test_retry_forward_directory.py
@@ -112,7 +112,9 @@ class TestCopyFromLocalToRemoteDirectory(unittest.TestCase):
         self.ctx._copy_from_local_to_remote(local_dir, remote_dir)
 
         self.assertTrue(os.path.exists(os.path.join(remote_dir, "top.txt")))
-        self.assertTrue(os.path.exists(os.path.join(remote_dir, "subdir", "nested.txt")))
+        self.assertTrue(
+            os.path.exists(os.path.join(remote_dir, "subdir", "nested.txt"))
+        )
         with open(os.path.join(remote_dir, "subdir", "nested.txt")) as f:
             self.assertEqual(f.read(), "nested")
 

--- a/tests/test_retry_forward_directory.py
+++ b/tests/test_retry_forward_directory.py
@@ -1,4 +1,4 @@
-"""Regression test for PR #629 reviewer issue: retry upload with forwarded directories.
+"""Regression test for retry upload with forwarded directories.
 
 Verifies that `_copy_from_local_to_remote` and `context.upload()` handle
 existing remote directories correctly without raising `IsADirectoryError`.

--- a/tests/test_retry_reupload.py
+++ b/tests/test_retry_reupload.py
@@ -5,12 +5,11 @@ import shutil
 import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dpdispatcher.submission import Job
-from dpdispatcher.utils.job_status import JobStatus
 
 
 class TestEnsureForwardFilesOnRetry(unittest.TestCase):

--- a/tests/test_retry_reupload.py
+++ b/tests/test_retry_reupload.py
@@ -1,0 +1,156 @@
+"""Test _ensure_forward_files_on_retry for PR #629."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from dpdispatcher.submission import Job
+from dpdispatcher.utils.job_status import JobStatus
+
+
+class TestEnsureForwardFilesOnRetry(unittest.TestCase):
+    """Tests for Job._ensure_forward_files_on_retry()."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.local_root = os.path.join(self.tmpdir, "local")
+        self.remote_root = os.path.join(self.tmpdir, "remote")
+        os.makedirs(self.local_root)
+        os.makedirs(self.remote_root)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _make_job_with_context(self, forward_files, task_work_path="task0"):
+        """Create a Job with LocalContext-like mock."""
+        job = Job.__new__(Job)
+        job.machine = MagicMock()
+        job.machine.context.remote_root = self.remote_root
+        job.machine.context.local_root = self.local_root
+
+        # LocalContext: has _copy_from_local_to_remote
+        def copy_fn(src, dst):
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.copy2(src, dst)
+
+        job.machine.context._copy_from_local_to_remote = copy_fn
+
+        def check_exists(fname):
+            return os.path.isfile(os.path.join(self.remote_root, fname))
+
+        job.machine.context.check_file_exists = check_exists
+
+        # Create task
+        task = MagicMock()
+        task.task_work_path = task_work_path
+        task.forward_files = forward_files
+        job.job_task_list = [task]
+        job._submission = None
+
+        return job
+
+    def test_reupload_missing_text_file(self):
+        """Missing text file on remote gets re-uploaded."""
+        job = self._make_job_with_context(["input.lammps"])
+
+        # Create local file
+        local_task = os.path.join(self.local_root, "task0")
+        os.makedirs(local_task)
+        with open(os.path.join(local_task, "input.lammps"), "w") as f:
+            f.write("pair_style deepmd\n")
+
+        # Remote task dir exists but file missing
+        os.makedirs(os.path.join(self.remote_root, "task0"))
+
+        job._ensure_forward_files_on_retry()
+
+        # File should now exist on remote
+        remote_file = os.path.join(self.remote_root, "task0", "input.lammps")
+        self.assertTrue(os.path.exists(remote_file))
+        with open(remote_file) as f:
+            self.assertEqual(f.read(), "pair_style deepmd\n")
+
+    def test_reupload_binary_file_not_corrupted(self):
+        """Binary .pb file must not be corrupted during re-upload."""
+        job = self._make_job_with_context(["frozen_model.pb"])
+
+        local_task = os.path.join(self.local_root, "task0")
+        os.makedirs(local_task)
+        # Write binary content (simulating a protobuf model file)
+        binary_content = bytes(range(256)) * 100  # 25.6 KB binary
+        with open(os.path.join(local_task, "frozen_model.pb"), "wb") as f:
+            f.write(binary_content)
+
+        os.makedirs(os.path.join(self.remote_root, "task0"))
+
+        job._ensure_forward_files_on_retry()
+
+        remote_file = os.path.join(self.remote_root, "task0", "frozen_model.pb")
+        self.assertTrue(os.path.exists(remote_file))
+        with open(remote_file, "rb") as f:
+            self.assertEqual(f.read(), binary_content)
+
+    def test_glob_pattern_expanded(self):
+        """Glob patterns like '*.pb' in forward_files are properly expanded."""
+        job = self._make_job_with_context(["*.pb"])
+
+        local_task = os.path.join(self.local_root, "task0")
+        os.makedirs(local_task)
+        for name in ["graph.000.pb", "graph.001.pb"]:
+            with open(os.path.join(local_task, name), "wb") as f:
+                f.write(b"model_data")
+
+        os.makedirs(os.path.join(self.remote_root, "task0"))
+
+        job._ensure_forward_files_on_retry()
+
+        for name in ["graph.000.pb", "graph.001.pb"]:
+            remote_file = os.path.join(self.remote_root, "task0", name)
+            self.assertTrue(os.path.exists(remote_file), f"{name} not re-uploaded")
+
+    def test_already_exists_not_recopied(self):
+        """Files already on remote should not be re-uploaded."""
+        job = self._make_job_with_context(["input.lammps"])
+
+        local_task = os.path.join(self.local_root, "task0")
+        os.makedirs(local_task)
+        with open(os.path.join(local_task, "input.lammps"), "w") as f:
+            f.write("local version")
+
+        remote_task = os.path.join(self.remote_root, "task0")
+        os.makedirs(remote_task)
+        with open(os.path.join(remote_task, "input.lammps"), "w") as f:
+            f.write("remote version")
+
+        job._ensure_forward_files_on_retry()
+
+        # Remote file should NOT be overwritten
+        with open(os.path.join(remote_task, "input.lammps")) as f:
+            self.assertEqual(f.read(), "remote version")
+
+    def test_no_machine_is_noop(self):
+        """If machine is None, method is a no-op."""
+        job = Job.__new__(Job)
+        job.machine = None
+        job.job_task_list = []
+        # Should not raise
+        job._ensure_forward_files_on_retry()
+
+    def test_missing_locally_and_remotely_logs_warning(self):
+        """File missing both locally and remotely — should not crash."""
+        job = self._make_job_with_context(["nonexistent.txt"])
+
+        os.makedirs(os.path.join(self.local_root, "task0"))
+        os.makedirs(os.path.join(self.remote_root, "task0"))
+
+        # Should not raise (just logs warning internally via glob finding nothing)
+        job._ensure_forward_files_on_retry()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retry_reupload.py
+++ b/tests/test_retry_reupload.py
@@ -1,20 +1,93 @@
-"""Test _ensure_forward_files_on_retry for PR #629."""
+"""Test _ensure_forward_files_on_retry for PR #629.
+
+Tests verify that:
+1. context.upload() is called on retry with the job's tasks
+2. forward_common_files from submission are included
+3. Exceptions don't crash the retry loop (handled at call site)
+4. No-machine case is a no-op
+5. Binary files are uploaded intact (integration test with real LocalContext)
+"""
 
 import os
 import shutil
 import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dpdispatcher.submission import Job
-from dpdispatcher.utils.job_status import JobStatus
 
 
 class TestEnsureForwardFilesOnRetry(unittest.TestCase):
-    """Tests for Job._ensure_forward_files_on_retry()."""
+    """Unit tests for Job._ensure_forward_files_on_retry()."""
+
+    def _make_job(self, task_list=None, forward_common_files=None):
+        """Create a Job with mocked machine/context."""
+        job = Job.__new__(Job)
+        job.machine = MagicMock()
+        job.machine.context.upload = MagicMock()
+
+        mock_submission = MagicMock()
+        mock_submission.forward_common_files = forward_common_files or []
+        job.machine.context.submission = mock_submission
+
+        if task_list is None:
+            task = MagicMock()
+            task.task_work_path = "task0"
+            task.forward_files = ["input.lammps", "frozen_model.pb"]
+            task_list = [task]
+        job.job_task_list = task_list
+        return job
+
+    def test_calls_context_upload(self):
+        """Calls context.upload() exactly once."""
+        job = self._make_job()
+        job._ensure_forward_files_on_retry()
+        job.machine.context.upload.assert_called_once()
+
+    def test_payload_contains_job_tasks(self):
+        """Upload payload contains this job's task list."""
+        task = MagicMock()
+        task.task_work_path = "task0"
+        task.forward_files = ["*.pb"]
+        job = self._make_job(task_list=[task])
+        job._ensure_forward_files_on_retry()
+        payload = job.machine.context.upload.call_args[0][0]
+        self.assertEqual(payload.belonging_tasks, [task])
+
+    def test_payload_contains_forward_common_files(self):
+        """Upload payload includes forward_common_files from submission."""
+        job = self._make_job(forward_common_files=["shared_model.pb"])
+        job._ensure_forward_files_on_retry()
+        payload = job.machine.context.upload.call_args[0][0]
+        self.assertEqual(payload.forward_common_files, ["shared_model.pb"])
+
+    def test_no_submission_on_context(self):
+        """If context has no submission attr, method returns early (no-op)."""
+        job = self._make_job()
+        del job.machine.context.submission
+        job._ensure_forward_files_on_retry()
+        job.machine.context.upload.assert_not_called()
+
+    def test_no_machine_is_noop(self):
+        """If machine is None, method is a no-op."""
+        job = Job.__new__(Job)
+        job.machine = None
+        job.job_task_list = []
+        job._ensure_forward_files_on_retry()
+
+    def test_upload_exception_propagates(self):
+        """Exceptions from upload propagate (caught at call site, not here)."""
+        job = self._make_job()
+        job.machine.context.upload.side_effect = FileNotFoundError("gone")
+        with self.assertRaises(FileNotFoundError):
+            job._ensure_forward_files_on_retry()
+
+
+class TestEnsureForwardFilesIntegration(unittest.TestCase):
+    """Integration test with real LocalContext."""
 
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -26,67 +99,30 @@ class TestEnsureForwardFilesOnRetry(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
-    def _make_job_with_context(self, forward_files, task_work_path="task0"):
-        """Create a Job with LocalContext-like mock."""
-        job = Job.__new__(Job)
-        job.machine = MagicMock()
-        job.machine.context.remote_root = self.remote_root
-        job.machine.context.local_root = self.local_root
+    def test_binary_file_integrity(self):
+        """Binary .pb file is uploaded without corruption."""
+        from dpdispatcher.contexts.local_context import LocalContext
 
-        # LocalContext: has _copy_from_local_to_remote
-        def copy_fn(src, dst):
-            os.makedirs(os.path.dirname(dst), exist_ok=True)
-            shutil.copy2(src, dst)
-
-        job.machine.context._copy_from_local_to_remote = copy_fn
-
-        def check_exists(fname):
-            return os.path.isfile(os.path.join(self.remote_root, fname))
-
-        job.machine.context.check_file_exists = check_exists
-
-        # Create task
-        task = MagicMock()
-        task.task_work_path = task_work_path
-        task.forward_files = forward_files
-        job.job_task_list = [task]
-        job._submission = None
-
-        return job
-
-    def test_reupload_missing_text_file(self):
-        """Missing text file on remote gets re-uploaded."""
-        job = self._make_job_with_context(["input.lammps"])
-
-        # Create local file
-        local_task = os.path.join(self.local_root, "task0")
-        os.makedirs(local_task)
-        with open(os.path.join(local_task, "input.lammps"), "w") as f:
-            f.write("pair_style deepmd\n")
-
-        # Remote task dir exists but file missing
-        os.makedirs(os.path.join(self.remote_root, "task0"))
-
-        job._ensure_forward_files_on_retry()
-
-        # File should now exist on remote
-        remote_file = os.path.join(self.remote_root, "task0", "input.lammps")
-        self.assertTrue(os.path.exists(remote_file))
-        with open(remote_file) as f:
-            self.assertEqual(f.read(), "pair_style deepmd\n")
-
-    def test_reupload_binary_file_not_corrupted(self):
-        """Binary .pb file must not be corrupted during re-upload."""
-        job = self._make_job_with_context(["frozen_model.pb"])
+        ctx = LocalContext.__new__(LocalContext)
+        ctx.local_root = self.local_root
+        ctx.remote_root = self.remote_root
+        ctx.symlink = False
+        ctx.submission = MagicMock()
+        ctx.submission.forward_common_files = []
 
         local_task = os.path.join(self.local_root, "task0")
         os.makedirs(local_task)
-        # Write binary content (simulating a protobuf model file)
-        binary_content = bytes(range(256)) * 100  # 25.6 KB binary
+        binary_content = bytes(range(256)) * 100
         with open(os.path.join(local_task, "frozen_model.pb"), "wb") as f:
             f.write(binary_content)
 
-        os.makedirs(os.path.join(self.remote_root, "task0"))
+        job = Job.__new__(Job)
+        job.machine = MagicMock()
+        job.machine.context = ctx
+        task = MagicMock()
+        task.task_work_path = "task0"
+        task.forward_files = ["frozen_model.pb"]
+        job.job_task_list = [task]
 
         job._ensure_forward_files_on_retry()
 
@@ -95,61 +131,38 @@ class TestEnsureForwardFilesOnRetry(unittest.TestCase):
         with open(remote_file, "rb") as f:
             self.assertEqual(f.read(), binary_content)
 
-    def test_glob_pattern_expanded(self):
-        """Glob patterns like '*.pb' in forward_files are properly expanded."""
-        job = self._make_job_with_context(["*.pb"])
+    def test_glob_expansion(self):
+        """Glob patterns in forward_files are expanded correctly."""
+        from dpdispatcher.contexts.local_context import LocalContext
+
+        ctx = LocalContext.__new__(LocalContext)
+        ctx.local_root = self.local_root
+        ctx.remote_root = self.remote_root
+        ctx.symlink = False
+        ctx.submission = MagicMock()
+        ctx.submission.forward_common_files = []
 
         local_task = os.path.join(self.local_root, "task0")
         os.makedirs(local_task)
         for name in ["graph.000.pb", "graph.001.pb"]:
             with open(os.path.join(local_task, name), "wb") as f:
-                f.write(b"model_data")
+                f.write(b"model")
 
-        os.makedirs(os.path.join(self.remote_root, "task0"))
+        job = Job.__new__(Job)
+        job.machine = MagicMock()
+        job.machine.context = ctx
+        task = MagicMock()
+        task.task_work_path = "task0"
+        task.forward_files = ["*.pb"]
+        job.job_task_list = [task]
 
         job._ensure_forward_files_on_retry()
 
         for name in ["graph.000.pb", "graph.001.pb"]:
-            remote_file = os.path.join(self.remote_root, "task0", name)
-            self.assertTrue(os.path.exists(remote_file), f"{name} not re-uploaded")
-
-    def test_already_exists_not_recopied(self):
-        """Files already on remote should not be re-uploaded."""
-        job = self._make_job_with_context(["input.lammps"])
-
-        local_task = os.path.join(self.local_root, "task0")
-        os.makedirs(local_task)
-        with open(os.path.join(local_task, "input.lammps"), "w") as f:
-            f.write("local version")
-
-        remote_task = os.path.join(self.remote_root, "task0")
-        os.makedirs(remote_task)
-        with open(os.path.join(remote_task, "input.lammps"), "w") as f:
-            f.write("remote version")
-
-        job._ensure_forward_files_on_retry()
-
-        # Remote file should NOT be overwritten
-        with open(os.path.join(remote_task, "input.lammps")) as f:
-            self.assertEqual(f.read(), "remote version")
-
-    def test_no_machine_is_noop(self):
-        """If machine is None, method is a no-op."""
-        job = Job.__new__(Job)
-        job.machine = None
-        job.job_task_list = []
-        # Should not raise
-        job._ensure_forward_files_on_retry()
-
-    def test_missing_locally_and_remotely_logs_warning(self):
-        """File missing both locally and remotely — should not crash."""
-        job = self._make_job_with_context(["nonexistent.txt"])
-
-        os.makedirs(os.path.join(self.local_root, "task0"))
-        os.makedirs(os.path.join(self.remote_root, "task0"))
-
-        # Should not raise (just logs warning internally via glob finding nothing)
-        job._ensure_forward_files_on_retry()
+            self.assertTrue(
+                os.path.exists(os.path.join(self.remote_root, "task0", name)),
+                f"{name} not uploaded",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_retry_reupload.py
+++ b/tests/test_retry_reupload.py
@@ -3,7 +3,7 @@
 Tests verify that:
 1. context.upload() is called on retry with the job's tasks
 2. forward_common_files from submission are included
-3. Exceptions don't crash the retry loop (handled at call site)
+3. Restoration exceptions stop resubmission and remain actionable
 4. No-machine case is a no-op
 5. Binary files are uploaded intact (integration test with real LocalContext)
 """
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from dpdispatcher.submission import Job
+from dpdispatcher.utils.job_status import JobStatus
 
 
 class TestEnsureForwardFilesOnRetry(unittest.TestCase):
@@ -113,11 +114,30 @@ class TestEnsureForwardFilesOnRetry(unittest.TestCase):
         job._ensure_forward_files_on_retry()
 
     def test_upload_exception_propagates(self):
-        """Exceptions from upload propagate (caught at call site, not here)."""
+        """Exceptions from upload propagate to the retry caller."""
         job = self._make_job()
         job.machine.context.upload.side_effect = FileNotFoundError("gone")
         with self.assertRaises(FileNotFoundError):
             job._ensure_forward_files_on_retry()
+
+    def test_restore_failure_prevents_resubmission(self):
+        """A terminated job is not resubmitted without its required inputs."""
+        job = self._make_job()
+        job.job_state = JobStatus.terminated
+        job.job_hash = "job-hash"
+        job.job_id = "job-id"
+        job.fail_count = 0
+        job.resources = MagicMock(wait_time=0)
+        job.machine.retry_count = 3
+        job._ensure_forward_files_on_retry = MagicMock(
+            side_effect=FileNotFoundError("missing input")
+        )
+        job.submit_job = MagicMock()
+
+        with self.assertRaisesRegex(FileNotFoundError, "missing input"):
+            job.handle_unexpected_job_state()
+
+        job.submit_job.assert_not_called()
 
 
 class TestEnsureForwardFilesIntegration(unittest.TestCase):

--- a/tests/test_retry_reupload.py
+++ b/tests/test_retry_reupload.py
@@ -64,6 +64,40 @@ class TestEnsureForwardFilesOnRetry(unittest.TestCase):
         payload = job.machine.context.upload.call_args[0][0]
         self.assertEqual(payload.forward_common_files, ["shared_model.pb"])
 
+    def test_payload_contains_retry_job(self):
+        """Upload payload includes the job collection required by cloud contexts."""
+        job = self._make_job()
+        job._ensure_forward_files_on_retry()
+        payload = job.machine.context.upload.call_args[0][0]
+        self.assertEqual(payload.belonging_jobs, [job])
+
+    def test_cloud_upload_contexts_receive_retry_job(self):
+        """Both cloud upload implementations can consume the retry payload."""
+        from dpdispatcher.contexts.dp_cloud_server_context import (
+            BohriumContext,
+        )
+        from dpdispatcher.contexts.openapi_context import (
+            OpenAPIContext,
+        )
+        from dpdispatcher.utils.job_status import (
+            JobStatus,
+        )
+
+        for upload_method in (OpenAPIContext.upload, BohriumContext.upload):
+            with self.subTest(context=upload_method.__qualname__):
+                job = self._make_job(forward_common_files=["shared_model.pb"])
+                job.job_state = JobStatus.terminated
+                context = job.machine.context
+                context.upload_job = MagicMock()
+
+                def run_real_upload(payload, method=upload_method, ctx=context):
+                    return method(ctx, payload)
+
+                context.upload.side_effect = run_real_upload
+                job._ensure_forward_files_on_retry()
+
+                context.upload_job.assert_called_once_with(job, ["shared_model.pb"])
+
     def test_no_submission_on_context(self):
         """If context has no submission attr, method returns early (no-op)."""
         job = self._make_job()


### PR DESCRIPTION
## Problem

When a Shell batch job terminates and dpdispatcher retries via `handle_unexpected_job_state`, it calls `submit_job()` directly without re-uploading forward_files. If files were removed from remote_root between attempts (NFS race, clean from parallel process, or wrapper timing), the retry fails with `No such file or directory`.

## Solution

Add `_ensure_forward_files_on_retry()` to Job class, called before `submit_job()` on retry. Checks each forward_file on remote and re-uploads from local if missing. No-op when files already exist.

## Backward compatible
Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job retry reliability by restoring forwarded input files before resubmission.
  * Supports files, glob-pattern matches, binary files, shared forwarded files, and directories.
  * Reliably replaces existing files, directories, and symlinks, including broken symlinks.
  * Preserves existing shared files while adding missing ones.
  * Upload failures are logged as warnings without blocking job resubmission.

* **Tests**
  * Added coverage for retry uploads, cloud contexts, glob expansion, binary integrity, directory handling, symlink replacement, and partial or missing remote state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->