### PR TITLE
fix(cli): allow preserving remote submissions

### DIFF
--- a/doc/submit.md
+++ b/doc/submit.md
@@ -28,3 +28,8 @@ The JSON entries for submission are defined as follows:
 - `--dry-run`: Only upload files without submitting.
 - `--exit-on-submit`: Exit after submitting without waiting for completion.
 - `--allow-ref`: Allow loading external JSON/YAML snippets through `$ref` (disabled by default for security).
+- `--no-clean`: Keep the remote submission directory after results are downloaded.
+
+By default, `dpdisp submit` removes the submission-specific remote directory after
+downloading the declared `backward_files` and `backward_common_files`. Use
+`--no-clean` when the complete remote directory must remain available for inspection.

--- a/dpdispatcher/dpdisp.py
+++ b/dpdispatcher/dpdisp.py
@@ -127,6 +127,15 @@ def main_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Allow loading external JSON/YAML snippets through `$ref`. Disabled by default for security.",
     )
+    parser_submit.add_argument(
+        "--no-clean",
+        action="store_false",
+        dest="clean",
+        help=(
+            "Keep the remote submission directory after downloading results. "
+            "By default the remote directory is removed."
+        ),
+    )
     return parser
 
 
@@ -171,6 +180,7 @@ def main():
             dry_run=args.dry_run,
             exit_on_submit=args.exit_on_submit,
             allow_ref=args.allow_ref,
+            clean=args.clean,
         )
     elif args.command is None:
         pass

--- a/dpdispatcher/entrypoints/submit.py
+++ b/dpdispatcher/entrypoints/submit.py
@@ -139,6 +139,7 @@ def submit(
     dry_run: bool = False,
     exit_on_submit: bool = False,
     allow_ref: bool = False,
+    clean: bool = True,
 ) -> None:
     """Submit a submission from a JSON file.
 
@@ -153,6 +154,12 @@ def submit(
     allow_ref : bool, default=False
         Whether to allow loading external JSON/YAML snippets via ``$ref``.
         Disabled by default for security.
+    clean : bool, default=True
+        Whether to remove the remote submission directory after downloading results.
+        Disable this when the complete remote work directory must remain available
+        for inspection.
     """
     submission = load_submission_from_json(filename, allow_ref=allow_ref)
-    submission.run_submission(dry_run=dry_run, exit_on_submit=exit_on_submit)
+    submission.run_submission(
+        dry_run=dry_run, exit_on_submit=exit_on_submit, clean=clean
+    )

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -5,9 +5,13 @@ import subprocess as sp
 import sys
 import tempfile
 import unittest
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 __package__ = "tests"
+
+from dpdispatcher.dpdisp import parse_args
+from dpdispatcher.entrypoints.submit import submit
 
 
 class TestSubmitCommand(unittest.TestCase):
@@ -56,8 +60,29 @@ class TestSubmitCommand(unittest.TestCase):
 
     def test_submit_help(self) -> None:
         """Test dpdisp submit --help."""
-        output = sp.check_output(["dpdisp", "submit", "-h"])  # noqa: S603, S607
+        output = sp.check_output(  # noqa: S603
+            [sys.executable, "-m", "dpdispatcher.dpdisp", "submit", "-h"],
+            cwd=os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+        )
         self.assertIn(b"--allow-ref", output)
+        self.assertIn(b"--no-clean", output)
+
+    def test_submit_clean_flags(self) -> None:
+        """Test that remote cleanup remains default but can be disabled."""
+        self.assertTrue(parse_args(["submit", self.json_file]).clean)
+        self.assertFalse(parse_args(["submit", "--no-clean", self.json_file]).clean)
+
+    @patch("dpdispatcher.entrypoints.submit.load_submission_from_json")
+    def test_submit_forwards_no_clean(self, load_submission: MagicMock) -> None:
+        """Test that the entry point forwards the cleanup choice."""
+        submission = MagicMock()
+        load_submission.return_value = submission
+
+        submit(filename=self.json_file, clean=False)
+
+        submission.run_submission.assert_called_once_with(
+            dry_run=False, exit_on_submit=False, clean=False
+        )
 
     def test_submit_allow_ref_flag(self) -> None:
         """Test dpdisp submit --allow-ref."""


### PR DESCRIPTION
## Summary

- add dpdisp submit --no-clean to preserve the remote submission directory
- keep the existing cleanup behavior as the default for backward compatibility
- document that default cleanup removes the submission-specific remote directory after declared backward files are downloaded
- cover parser defaults and forwarding to Submission.run_submission

This complements #627: that PR adds programmatic cleanup strategies, while this PR exposes an opt-out through the JSON submission CLI.

Closes #595

## Validation

- python -m coverage run -p --source=./dpdispatcher -m unittest -v (165 passed, 42 skipped)
- python -m coverage combine && python -m coverage report
- uvx pre-commit run --all-files
- uvx --from ty==0.0.17 --with .[cloudserver,gui] --with tomli ty check
- python -m dpdispatcher.dpdisp submit --help
- dpdisp run examples/dpdisp_run.py
- make -C doc clean html (succeeded with existing documentation warnings)

Standalone Pyright continues to report the existing repository baseline; the project CI type checker passes.

Coding agent: Codex
Codex version: codex-cli 0.149.0
Model: gpt-5.6-sol
Reasoning effort: xhigh