### PR TITLE
fix: replace LocalContext upload destinations

### DIFF
--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -92,8 +92,13 @@ class LocalContext(BaseContext):
             raise FileNotFoundError(
                 f"cannot find uploaded file {os.path.join(local_path)}"
             )
-        if os.path.exists(remote_path):
-            os.remove(remote_path)
+        # ``lexists`` also finds broken symlinks, which must be unlinked before
+        # copying instead of accidentally following their missing target.
+        if os.path.lexists(remote_path):
+            if os.path.isdir(remote_path) and not os.path.islink(remote_path):
+                shutil.rmtree(remote_path)
+            else:
+                os.remove(remote_path)
         _check_file_path(remote_path)
 
         if self.symlink:

--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -88,7 +88,7 @@ class LocalContext(BaseContext):
             self.temp_remote_root, submission.submission_hash
         )
 
-    def _copy_from_local_to_remote(self, local_path, remote_path):
+    def _copy_from_local_to_remote(self, local_path: str, remote_path: str) -> None:
         if not os.path.exists(local_path):
             raise FileNotFoundError(
                 f"cannot find uploaded file {os.path.join(local_path)}"

--- a/tests/test_local_context.py
+++ b/tests/test_local_context.py
@@ -3,6 +3,7 @@ import hashlib
 import os
 import shutil
 import sys
+import tempfile
 import unittest
 import uuid
 from unittest.mock import MagicMock
@@ -104,6 +105,47 @@ class TestLocalContext(unittest.TestCase):
             f1 = os.path.join(self.tmp_local_root, "0_md/", file)
             f2 = os.path.join(self.tmp_remote_root, submission_hash, file)
             self.assertEqual(get_file_md5(f1), get_file_md5(f2), msg=(f1, f2))
+
+    def test_copy_replaces_existing_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            local_path = os.path.join(temp_dir, "local")
+            remote_path = os.path.join(temp_dir, "remote")
+            os.makedirs(local_path)
+            os.makedirs(remote_path)
+            with open(os.path.join(local_path, "new.txt"), "w") as fp:
+                fp.write("new")
+            with open(os.path.join(remote_path, "old.txt"), "w") as fp:
+                fp.write("old")
+
+            context = LocalContext(
+                local_root=temp_dir,
+                remote_root=temp_dir,
+                remote_profile={"symlink": False},
+            )
+            context._copy_from_local_to_remote(local_path, remote_path)
+
+            self.assertFalse(os.path.exists(os.path.join(remote_path, "old.txt")))
+            with open(os.path.join(remote_path, "new.txt")) as fp:
+                self.assertEqual(fp.read(), "new")
+
+    def test_copy_replaces_broken_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            local_path = os.path.join(temp_dir, "local.txt")
+            remote_path = os.path.join(temp_dir, "remote.txt")
+            with open(local_path, "w") as fp:
+                fp.write("new")
+            os.symlink("missing.txt", remote_path)
+
+            context = LocalContext(
+                local_root=temp_dir,
+                remote_root=temp_dir,
+                remote_profile={"symlink": False},
+            )
+            context._copy_from_local_to_remote(local_path, remote_path)
+
+            self.assertFalse(os.path.islink(remote_path))
+            with open(remote_path) as fp:
+                self.assertEqual(fp.read(), "new")
 
     # TODO: support other platforms
     @unittest.skipIf(sys.platform != "linux", "not linux")


### PR DESCRIPTION
## Summary

- detect existing destinations with lexists so broken symlinks are handled
- remove destination directories recursively and unlink files or symlinks before copying
- allow repeated LocalContext directory uploads to replace prior remote content safely

Closes #616

## Validation

- full unit suite passed
- 14 focused LocalContext tests passed
- pre-commit and Ruff checks passed
- exact CI ty==0.0.17 check passed
- CLI smoke checks passed

Repository-wide Pyright retains unrelated baseline diagnostics.

Coding agent: Codex
Codex version: codex-cli 0.149.0
Model: gpt-5.6-sol
Reasoning effort: xhigh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local-to-remote copying when the destination already exists.
  - Existing directories are replaced correctly.
  - Broken symbolic links are safely replaced with regular files.

- **Tests**
  - Added coverage for replacing existing directories.
  - Added coverage for replacing broken symbolic links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->