### PR TITLE
fix(ci): rename type checker workflow to ty

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install development tools
         run: |
           uv tool install pre-commit
-          uv tool install pyright
+          uv tool install ty==0.0.17
 
       - name: Set up pre-commit hooks
         run: |
@@ -61,5 +61,5 @@ jobs:
           python --version
           uv --version
           pre-commit --version
-          pyright --version
+          ty --version
           python -c "import dpdispatcher; print('DPDispatcher installed successfully')"

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -5,13 +5,14 @@
       - 'dependabot/**'
       - 'pre-commit-ci-update-config'
   pull_request:
-name: Type checker
+name: ty
 jobs:
-  test:
-    name: pyright
+  ty:
+    name: ty
     runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v7
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v7
-    - run: uvx --from ty==0.0.17 --with .[cloudserver,gui] --with tomli ty check
+    - name: Run ty
+      run: uvx --from ty==0.0.17 --with .[cloudserver,gui] --with tomli ty check

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -8,7 +8,8 @@
 name: ty
 jobs:
   ty:
-    name: ty
+    # for compatibility of rulesets
+    name: pyright
     runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Always reference these instructions first and fallback to search or bash command
 
 ### Bootstrap, Build, and Test
 
-- **Environment setup:** The Python environment, `uv`, `pre-commit`, and `pyright` are automatically set up by the Copilot environment. Simply activate the virtual environment:
+- **Environment setup:** The Python environment, `uv`, `pre-commit`, and `ty` are automatically set up by the Copilot environment. Simply activate the virtual environment:
 
   ```bash
   source .venv/bin/activate
@@ -36,7 +36,7 @@ Always reference these instructions first and fallback to search or bash command
 - **Run type checking:**
 
   ```bash
-  pyright
+  uvx --from ty==0.0.17 --with .[cloudserver,gui] --with tomli ty check
   ```
 
   - **TIMING: Type checking takes ~2-3 seconds.**
@@ -70,7 +70,7 @@ Always reference these instructions first and fallback to search or bash command
 
 - **ALWAYS run the test suite after making code changes.** Tests execute quickly (~25 seconds) and should never be cancelled.
 - **ALWAYS run linting before committing:** `pre-commit run --all-files`
-- **ALWAYS run type checking:** `pyright` to catch type-related issues.
+- **ALWAYS run type checking:** `uvx --from ty==0.0.17 --with .[cloudserver,gui] --with tomli ty check` to catch type-related issues.
 - **Test CLI functionality:** Run `dpdisp --help` and test with example scripts to ensure the CLI works correctly.
 - **Build documentation:** Run `make html` in the `doc/` directory to verify documentation builds without errors.
 
@@ -81,7 +81,7 @@ Always reference these instructions first and fallback to search or bash command
 - **Python versions:** Supports Python 3.7+ (check `pyproject.toml` for current support matrix).
 - **Testing:** Uses `unittest` framework with coverage reporting.
 - **Linting:** Uses `pre-commit` with `ruff` for linting and formatting, plus other quality checks.
-- **Type checking:** Uses `pyright` for static type analysis (configured in `pyproject.toml`).
+- **Type checking:** Uses `ty` for static type analysis (configured in `pyproject.toml`).
 - **Documentation:** Uses Sphinx with MyST parser for markdown support.
 
 ## Key Components
@@ -167,7 +167,7 @@ dpdisp run examples/dpdisp_run.py
 ## Troubleshooting
 
 - **Virtual environment issues:** The virtual environment is pre-created; simply activate with `source .venv/bin/activate`
-- **Development tools:** `pre-commit` and `pyright` are pre-installed and ready to use
+- **Development tools:** `pre-commit` and `ty` are pre-installed and ready to use
 - **Test failures:** Most tests run locally; some require specific HPC environments and will be skipped
 - **Documentation build warnings:** Some warnings about external inventory URLs are expected in sandboxed environments
 - **Pre-commit network issues:** If pre-commit fails with network timeouts, run `ruff check` and `ruff format` directly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,13 +74,6 @@ include = ["dpdispatcher*"]
 [tool.setuptools_scm]
 write_to = "dpdispatcher/_version.py"
 
-[tool.pyright]
-include = ['dpdispatcher']
-exclude = [
-    'dpdispatcher/dpcloudserver/temp_test.py',
-    'dpdispatcher/_version.py',
-]
-
 [tool.ty.src]
 include = ['dpdispatcher']
 exclude = [


### PR DESCRIPTION
## Summary

- rename the type-checking workflow and job to match the ty checker it actually runs
- align configuration and development documentation with the CI command
- retain the existing ty behavior while removing misleading Pyright naming

Closes #618

## Validation

- full unit suite: 163 passed, 42 skipped
- exact ty==0.0.17 CI command passed
- pre-commit and Ruff checks passed
- CLI smoke checks passed

Coding agent: Codex
Codex version: codex-cli 0.149.0
Model: gpt-5.6-sol
Reasoning effort: xhigh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Replaced Pyright with `ty` for static type checking in development workflows.
  - Updated automated validation to install, run, and verify `ty`.
  - Simplified type-checking configuration while preserving existing source inclusion and exclusion settings.

- **Documentation**
  - Updated setup, validation, workflow, and troubleshooting guidance to use `ty` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->