### PR TITLE
fix: hide generated job scripts

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -3,12 +3,21 @@
 DPDispatcher provides the following classes:
 
 - {class}`Task <dpdispatcher.submission.Task>` class, which represents a command to be run on batch job system, as well as the essential files need by the command.
+
 - {class}`Submission <dpdispatcher.submission.Submission>` class, which represents a collection of jobs defined by the HPC system.
   And there may be common files to be uploaded by them.
   DPDispatcher will create and submit these jobs when a `submission` instance execute {meth}`run_submission <dpdispatcher.submission.Submission.run_submission>` method.
   This method will poke until the jobs finish and return.
+
 - {class}`Job <dpdispatcher.submission.Job>` class, a class used by {class}`Submission <dpdispatcher.submission.Submission>` class, which represents a job on the HPC system.
   {class}`Submission <dpdispatcher.submission.Submission>` will generate `job`s' submitting scripts used by HPC systems automatically with the {class}`Task <dpdispatcher.submission.Task>` and {class}`Resources <dpdispatcher.submission.Resources>`
+
+  Generated submission and run scripts are internal, dot-prefixed files named
+  `.JOB_HASH.sub` and `.JOB_HASH.sub.run`. They remain in the submission work
+  directory for scheduler and recovery compatibility, but normal directory
+  listings hide them. Do not rename or remove them while a submission is active
+  or may need to be recovered.
+
 - {class}`Resources <dpdispatcher.submission.Resources>` class, which represents the computing resources for each job within a `submission`.
 
 You can use DPDispatcher in a Python script to submit five tasks:

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -803,7 +803,9 @@ class Job:
         self.job_uuid = uuid.uuid4()
 
         self.job_hash = self.get_hash()
-        self.script_file_name = self.job_hash + ".sub"
+        # Keep generated scheduler artifacts in the work root for compatibility with
+        # existing contexts, but hide them from normal directory listings.
+        self.script_file_name = f".{self.job_hash}.sub"
 
     def __repr__(self):
         return str(self.serialize())

--- a/tests/test_hidden_job_scripts.py
+++ b/tests/test_hidden_job_scripts.py
@@ -1,0 +1,112 @@
+import glob
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from zipfile import ZipFile
+
+from dpdispatcher.contexts.lazy_local_context import LazyLocalContext, SPRetObj
+from dpdispatcher.contexts.openapi_context import zip_file_list as openapi_zip_file_list
+from dpdispatcher.machines.distributed_shell import DistributedShell
+from dpdispatcher.machines.fugaku import Fugaku
+from dpdispatcher.machines.JH_UniScheduler import JH_UniScheduler
+from dpdispatcher.machines.lsf import LSF
+from dpdispatcher.machines.pbs import PBS, SGE, Torque
+from dpdispatcher.machines.shell import Shell
+from dpdispatcher.machines.slurm import Slurm, SlurmJobArray
+from dpdispatcher.submission import Job
+from dpdispatcher.utils.dpcloudserver.zip_file import (
+    zip_file_list as bohrium_zip_file_list,
+)
+
+from .context import setUpModule  # noqa: F401
+from .sample_class import SampleClass
+
+
+class TestHiddenJobScripts(unittest.TestCase):
+    def setUp(self):
+        self.job = SampleClass.get_sample_job()
+        self.expected_script_name = f".{self.job.job_hash}.sub"
+
+    def test_scheduler_scripts_source_hidden_run_file(self):
+        """All scheduler variants should use the hidden name without path changes."""
+        context = LazyLocalContext(local_root=".")
+        context.remote_root = "/tmp/dpdispatcher"
+        context.submission = SimpleNamespace(submission_hash="submission")
+
+        scheduler_classes = (
+            Shell,
+            Slurm,
+            SlurmJobArray,
+            PBS,
+            Torque,
+            SGE,
+            LSF,
+            Fugaku,
+            JH_UniScheduler,
+            DistributedShell,
+        )
+        for scheduler_class in scheduler_classes:
+            with self.subTest(scheduler=scheduler_class.__name__):
+                machine = scheduler_class(context=context)
+                self.job.machine = machine
+                script = machine.gen_script(self.job)
+
+                self.assertEqual(self.job.script_file_name, self.expected_script_name)
+                self.assertIn(
+                    f"source $REMOTE_ROOT/{self.expected_script_name}.run", script
+                )
+
+    def test_lazy_local_resubmission_and_recovery_use_hidden_paths(self):
+        """Recovered jobs regenerate hidden scripts while retaining their hash."""
+        with tempfile.TemporaryDirectory() as local_root:
+            context = LazyLocalContext(local_root=local_root)
+            context.bind_submission(SimpleNamespace(work_base="work"))
+            machine = Shell(context=context)
+            self.job.machine = machine
+
+            context.block_call = MagicMock(
+                return_value=(0, None, SPRetObj(b"123\n"), SPRetObj(b""))
+            )
+            self.job.submit_job()
+
+            script_path = os.path.join(context.remote_root, self.expected_script_name)
+            run_path = f"{script_path}.run"
+            self.assertTrue(os.path.isfile(script_path))
+            self.assertTrue(os.path.isfile(run_path))
+            visible_entries = [
+                os.path.basename(path)
+                for path in glob.glob(os.path.join(context.remote_root, "*"))
+            ]
+            self.assertNotIn(self.expected_script_name, visible_entries)
+            self.assertNotIn(f"{self.expected_script_name}.run", visible_entries)
+
+            recovered_job = Job.deserialize(self.job.serialize(), machine=machine)
+            self.assertEqual(recovered_job.job_hash, self.job.job_hash)
+            self.assertEqual(recovered_job.script_file_name, self.expected_script_name)
+
+            os.remove(script_path)
+            os.remove(run_path)
+            recovered_job.submit_job()
+            self.assertTrue(os.path.isfile(script_path))
+            self.assertTrue(os.path.isfile(run_path))
+
+    def test_cloud_archives_include_explicit_hidden_scripts(self):
+        """Cloud contexts list scripts explicitly, so dot prefixes remain uploadable."""
+        with tempfile.TemporaryDirectory() as local_root:
+            script_names = (
+                self.expected_script_name,
+                f"{self.expected_script_name}.run",
+            )
+            for script_name in script_names:
+                with open(os.path.join(local_root, script_name), "w") as script_file:
+                    script_file.write("#!/bin/bash\n")
+
+            archive_builders = (openapi_zip_file_list, bohrium_zip_file_list)
+            for index, archive_builder in enumerate(archive_builders):
+                with self.subTest(archive_builder=archive_builder.__module__):
+                    archive_name = f"scripts-{index}.zip"
+                    archive_builder(local_root, archive_name, list(script_names))
+                    with ZipFile(os.path.join(local_root, archive_name)) as archive:
+                        self.assertEqual(set(archive.namelist()), set(script_names))


### PR DESCRIPTION
## Summary

- prefix generated per-job submission and run scripts with a dot so normal directory listings omit dispatcher artifacts
- preserve the existing work-root layout, job hashes, recovery, resubmission, and scheduler behavior
- cover scheduler-wide generation, LazyLocal recovery/resubmission, and cloud archive upload paths
- document the hidden artifact names

Closes #400

## Validation

- full unit suite: 168 passed, 42 skipped
- focused scheduler, LazyLocal, recovery, resubmission, and cloud tests passed
- uvx pre-commit run --all-files passed
- changed-file Pyright passed
- CLI and documentation builds passed with existing warnings

Repository-wide Pyright retains unrelated baseline diagnostics.

Coding agent: Codex
Codex version: codex-cli 0.149.0
Model: gpt-5.6-sol
Reasoning effort: xhigh