### PR TITLE
docs: improve API documentation and docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,32 @@
-## How to contribute
+# How to contribute
 
-DPDispatcher welcomes every people (or organization) to use under the LGPL-3.0 License.
+DPDispatcher welcomes contributions from individuals and organizations under the LGPL-3.0 License.
 
-And Contributions are welcome and are greatly appreciated! Every little bit helps, and credit will always be given.
+Open an issue, submit a pull request, join a GitHub discussion, or contact the DeepModeling team. Improvements of every size are welcome, including:
 
-If you want to contribute to dpdispatcher, just open a issue, submiit a pull request , leave a comment on github discussion, or contact deepmodeling team.
+- using, starring, or forking DPDispatcher;
+- improving documentation and examples;
+- reporting or fixing bugs; and
+- requesting, discussing, or implementing features.
 
-Any forms of improvement are welcome.
+## Docstrings and documentation
 
-- use, star or fork dpdispatcher
-- improve the documents
-- report or fix bugs
-- request, discuss or implement features
+Public modules, classes, functions, and core API methods must have docstrings.
+DPDispatcher uses the NumPy docstring convention enforced by Ruff's `D` rules.
+Document behavior, parameters, return values, exceptions, important invariants,
+and backend-specific differences when they are not obvious from the signature.
+Avoid comments that merely repeat the function name.
+
+User-facing documentation lives in `doc/` and is built with Sphinx and MyST.
+Use Sphinx/MyST cross-references to API objects so renamed objects produce a
+documentation warning instead of a silent broken link. After documentation or
+Python changes, run:
+
+```bash
+pre-commit run --all-files
+pyright
+python -m coverage run -p --source=./dpdispatcher -m unittest -v
+python -m coverage combine
+python -m coverage report
+make -C doc html
+```

--- a/doc/batch.md
+++ b/doc/batch.md
@@ -3,9 +3,9 @@
 Batch job system is a system to process batch jobs.
 One needs to set {dargs:argument}`batch_type <machine/batch_type>` to one of the following values:
 
-## Bash
+## Shell
 
-{dargs:argument}`batch_type <resources/batch_type>`: `Shell`
+{dargs:argument}`batch_type <machine/batch_type>`: `Shell`
 
 When {dargs:argument}`batch_type <resources/batch_type>` is set to `Shell`, dpdispatcher will generate a bash script to process jobs.
 No extra packages are required for `Shell`.
@@ -15,7 +15,7 @@ To avoid running multiple jobs at the same time, one could set {dargs:argument}`
 
 ## Slurm
 
-{dargs:argument}`batch_type <resources/batch_type>`: `Slurm`, `SlurmJobArray`
+{dargs:argument}`batch_type <machine/batch_type>`: `Slurm`, `SlurmJobArray`
 
 [Slurm](https://slurm.schedmd.com/) is a job scheduling system used by lots of HPCs.
 One needs to make sure slurm has been set up in the remote server and the related environment is activated.
@@ -27,7 +27,7 @@ One can use {dargs:argument}`group_size <resources/group_size>` and {dargs:argum
 
 ## OpenPBS or PBSPro
 
-{dargs:argument}`batch_type <resources/batch_type>`: `PBS`
+{dargs:argument}`batch_type <machine/batch_type>`: `PBS`
 
 [OpenPBS](https://www.openpbs.org/) is an open-source job scheduling of the Linux Foundation and [PBS Profession](https://www.altair.com/pbs-professional/) is its commercial solution.
 One needs to make sure OpenPBS has been set up in the remote server and the related environment is activated.
@@ -36,7 +36,7 @@ Note that do not use `PBS` for Torque.
 
 ## TORQUE
 
-{dargs:argument}`batch_type <resources/batch_type>`: `Torque`
+{dargs:argument}`batch_type <machine/batch_type>`: `Torque`
 
 The [Terascale Open-source Resource and QUEue Manager (TORQUE)](https://adaptivecomputing.com/cherry-services/torque-resource-manager/) is a distributed resource manager based on standard OpenPBS.
 However, not all OpenPBS flags are still supported in TORQUE.
@@ -44,14 +44,14 @@ One needs to make sure TORQUE has been set up in the remote server and the relat
 
 ## LSF
 
-{dargs:argument}`batch_type <resources/batch_type>`: `LSF`
+{dargs:argument}`batch_type <machine/batch_type>`: `LSF`
 
 [IBM Spectrum LSF Suites](https://www.ibm.com/products/hpc-workload-management) is a comprehensive workload management solution used by HPCs.
 One needs to make sure LSF has been set up in the remote server and the related environment is activated.
 
 ## JH UniScheduler
 
-{dargs:argument}`batch_type <resources/batch_type>`: `JH_UniScheduler`
+{dargs:argument}`batch_type <machine/batch_type>`: `JH_UniScheduler`
 
 [JH UniScheduler](http://www.jhinno.com/m/custom_case_05.html) was developed by JHINNO company and uses "jsub" to submit tasks.
 Its overall architecture is similar to that of IBM's LSF. However, there are still some differences between them. One needs to
@@ -59,33 +59,34 @@ make sure JH UniScheduler has been set up in the remote server and the related e
 
 ## Bohrium
 
-{dargs:argument}`batch_type <resources/batch_type>`: `Bohrium`
+{dargs:argument}`batch_type <machine/batch_type>`: `Bohrium`
 
 Bohrium is the cloud platform for scientific computing.
 Read Bohrium documentation for details.
 
 ## DistributedShell
 
-{dargs:argument}`batch_type <resources/batch_type>`: `DistributedShell`
+{dargs:argument}`batch_type <machine/batch_type>`: `DistributedShell`
 
 `DistributedShell` is used to submit yarn jobs.
 Read [Support DPDispatcher on Yarn](dpdispatcher_on_yarn.md) for details.
 
 ## Fugaku
 
-{dargs:argument}`batch_type <resources/batch_type>`: `Fugaku`
+{dargs:argument}`batch_type <machine/batch_type>`: `Fugaku`
 
-[Fujitsu cloud service](https://doc.cloud.global.fujitsu.com/lib/common/jp/hpc-user-manual/) is a job scheduling system used by Fujitsu's HPCs such as Fugaku, ITO and K computer. It should be noted that although the same job scheduling system is used, there are some differences in the details, Fagaku class cannot be directly used for other HPCs.
+[Fujitsu cloud service](https://doc.cloud.global.fujitsu.com/lib/common/jp/hpc-user-manual/) provides the scheduler used by systems such as Fugaku, ITO, and the K computer. Site-specific differences mean that DPDispatcher's `Fugaku` backend may not work unchanged on other Fujitsu systems.
 
 Read Fujitsu cloud service documentation for details.
 
 ## OpenAPI
 
-{dargs:argument}`batcy_type <resources/batch_type>`: `OpenAPI`
-OpenAPI is a new way to submit jobs to Bohrium. It is using [AccessKey](https://bohrium.dp.tech/personal/setting) instead of username and password. Read Bohrium documentation for details.
+{dargs:argument}`batch_type <machine/batch_type>`: `OpenAPI`
+
+OpenAPI submits jobs to Bohrium using an [AccessKey](https://bohrium.dp.tech/personal/setting) instead of a username and password. Read the Bohrium documentation for details.
 
 ## SGE
 
-{dargs:argument}`batch_type <resources/batch_type>`: `SGE`
+{dargs:argument}`batch_type <machine/batch_type>`: `SGE`
 
 The [Sun Grid Engine (SGE) scheduler](https://gridscheduler.sourceforge.net) is a batch-queueing system distributed resource management. The commands and flags of SGE share a lot of similarity with PBS except when checking job status. Use this argument if one is submitting job to an SGE-based batch system.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+"""Configure the Sphinx documentation build for DPDispatcher."""
+
 import os
 import sys
 from datetime import date
@@ -78,6 +80,8 @@ master_doc = "index"
 
 
 def run_apidoc(_: Any) -> None:  # noqa: ANN401
+    """Generate API source pages before Sphinx reads the documentation tree."""
+
     from sphinx.ext.apidoc import main
 
     sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
@@ -99,6 +103,8 @@ def run_apidoc(_: Any) -> None:  # noqa: ANN401
 
 
 def setup(app: Any) -> None:  # noqa: ANN401
+    """Register documentation-build hooks."""
+
     app.connect("builder-inited", run_apidoc)
 
 

--- a/doc/context.md
+++ b/doc/context.md
@@ -27,7 +27,7 @@ Since [`bash -l`](https://www.gnu.org/software/bash/manual/bash.html#Invoking-Ba
 
 `SSH` runs jobs in a remote server.
 Files will be copied to the remote directory via SSH channels before jobs start and copied back after jobs finish.
-To use SSH, one needs to provide necessary parameters in {dargs:argument}`remote_profile <machine[SSHContext]/remote_profile>`, such as {dargs:argument}`username <machine[SSHContext]/remote_profile/hostname>` and {dargs:argument}`hostname <username[SSHContext]/remote_profile/hostname>`.
+To use SSH, provide the connection parameters in {dargs:argument}`remote_profile <machine[SSHContext]/remote_profile>`, including {dargs:argument}`username <machine[SSHContext]/remote_profile/username>` and {dargs:argument}`hostname <machine[SSHContext]/remote_profile/hostname>`.
 
 By default, DPDispatcher creates only the final {dargs:argument}`remote_root <machine/remote_root>` component and requires its parent directory to already exist. To recursively create missing parent directories, set {dargs:argument}`create_remote_root <machine[SSHContext]/create_remote_root>` to `true`.
 
@@ -76,5 +76,5 @@ Read [Support DPDispatcher on Yarn](dpdispatcher_on_yarn.md) for details.
 
 {dargs:argument}`context_type <machine/context_type>`: `OpenAPI`
 
-OpenAPI is a new way to submit jobs to Bohrium. It using [AccessKey](https://bohrium.dp.tech/personal/setting) instead of username and password. Read Bohrium documentation for details.
+OpenAPI submits jobs to Bohrium using an [AccessKey](https://bohrium.dp.tech/personal/setting) instead of a username and password. Read the Bohrium documentation for details.
 To use OpenAPI, one needs to provide necessary parameters in {dargs:argument}`remote_profile <machine[OpenAPIContext]/remote_profile>`.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,29 +1,25 @@
 # Getting Started
 
-DPDispatcher provides the following classes:
+DPDispatcher provides the following core classes:
 
-- {class}`Task <dpdispatcher.submission.Task>` class, which represents a command to be run on batch job system, as well as the essential files need by the command.
+- {class}`Task <dpdispatcher.submission.Task>` represents one command, its working directory, and the files that must be staged before and after execution.
+- {class}`Resources <dpdispatcher.submission.Resources>` describes the CPUs, GPUs, queue, task grouping, and environment required by each generated job.
+- {class}`Submission <dpdispatcher.submission.Submission>` groups tasks, generates jobs, transfers files, submits work, monitors it, and downloads results.
+- {class}`Job <dpdispatcher.submission.Job>` represents one generated scheduler job. Applications normally inspect jobs but let `Submission` create them automatically.
 
-- {class}`Submission <dpdispatcher.submission.Submission>` class, which represents a collection of jobs defined by the HPC system.
-  And there may be common files to be uploaded by them.
-  DPDispatcher will create and submit these jobs when a `submission` instance execute {meth}`run_submission <dpdispatcher.submission.Submission.run_submission>` method.
-  This method will poke until the jobs finish and return.
+See the {doc}`python-api` guide for path semantics, grouping, lifecycle options,
+asynchronous submissions, and backend extension points.
 
-- {class}`Job <dpdispatcher.submission.Job>` class, a class used by {class}`Submission <dpdispatcher.submission.Submission>` class, which represents a job on the HPC system.
-  {class}`Submission <dpdispatcher.submission.Submission>` will generate `job`s' submitting scripts used by HPC systems automatically with the {class}`Task <dpdispatcher.submission.Task>` and {class}`Resources <dpdispatcher.submission.Resources>`
-
-  Generated submission and run scripts are internal, dot-prefixed files named
-  `.JOB_HASH.sub` and `.JOB_HASH.sub.run`. They remain in the submission work
-  directory for scheduler and recovery compatibility, but normal directory
-  listings hide them. Do not rename or remove them while a submission is active
-  or may need to be recovered.
-
-- {class}`Resources <dpdispatcher.submission.Resources>` class, which represents the computing resources for each job within a `submission`.
+Generated submission and run scripts are internal, dot-prefixed files named
+`.JOB_HASH.sub` and `.JOB_HASH.sub.run`. They remain in the submission work
+directory for scheduler and recovery compatibility, but normal directory
+listings hide them. Do not rename or remove them while a submission is active
+or may need to be recovered.
 
 You can use DPDispatcher in a Python script to submit five tasks:
 
 ```python
-from dpdispatcher import Machine, Resources, Task, Submission
+from dpdispatcher import Machine, Resources, Submission, Task
 
 machine = Machine.load_from_json("machine.json")
 resources = Resources.load_from_json("resources.json")
@@ -120,8 +116,7 @@ and `task.json` is
 }
 ```
 
-You may also submit multiple GPU jobs:
-complex resources example
+You may also run multiple GPU tasks within each generated job:
 
 ```python3
 resources = Resources(
@@ -132,7 +127,7 @@ resources = Resources(
     group_size=4,
     custom_flags=["#SBATCH --nice=100", "#SBATCH --time=24:00:00"],
     strategy={
-        # used when you want to add CUDA_VISIBLE_DIVECES automatically
+        # Add CUDA_VISIBLE_DEVICES automatically for concurrent tasks.
         "if_cuda_multi_devices": True
     },
     para_deg=1,
@@ -149,4 +144,5 @@ resources = Resources(
 )
 ```
 
-The details of parameters can be found in [Machine Parameters](machine), [Resources Parameters](resources), and [Task Parameters](task).
+Parameter details are available in {doc}`Machine parameters <machine>`,
+{doc}`Resources parameters <resources>`, and {doc}`Task parameters <task>`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,9 +6,12 @@
 DPDispatcher's documentation
 ======================================
 
-DPDispatcher is a Python package used to generate HPC (High Performance Computing) scheduler systems (Slurm/PBS/LSF/JH_SCheduler/dpcloudserver) jobs input scripts and submit these scripts to HPC systems and poke until they finish.
+DPDispatcher generates job scripts for HPC schedulers such as Slurm, PBS, LSF,
+JH UniScheduler, and cloud backends. It submits those jobs, monitors them until
+completion, and transfers declared input and result files.
 
-DPDispatcher will monitor (poke) until these jobs finish and download the results files (if these jobs is running on remote systems connected by SSH).
+The same Python API works with local shell execution, SSH-connected clusters,
+distributed filesystems, and supported cloud services.
 
 Please cite the following paper if you use this project in your work:
 
@@ -26,8 +29,10 @@ Please cite the following paper if you use this project in your work:
 
    install
    getting-started
+   python-api
    context
    batch
+   dpdispatcher_on_yarn
    machine
    resources
    task

--- a/doc/install.md
+++ b/doc/install.md
@@ -1,6 +1,6 @@
 # Install DPDispatcher
 
-DPDispatcher can installed by `pip`:
+DPDispatcher can be installed with `pip`:
 
 ```bash
 pip install dpdispatcher

--- a/doc/python-api.md
+++ b/doc/python-api.md
@@ -1,0 +1,159 @@
+# Python API guide
+
+Most Python integrations use four objects imported directly from
+`dpdispatcher`:
+
+| Object                            | Responsibility                                                                            |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| {class}`~dpdispatcher.Machine`    | Selects a batch backend and an execution context.                                         |
+| {class}`~dpdispatcher.Resources`  | Describes the resources and grouping strategy for each generated job.                     |
+| {class}`~dpdispatcher.Task`       | Describes one command, its working directory, and the files to transfer.                  |
+| {class}`~dpdispatcher.Submission` | Groups tasks, generates jobs, transfers files, monitors execution, and downloads results. |
+
+{class}`~dpdispatcher.Job` is also public because it is useful for inspection and
+recovery, but applications normally let
+{meth}`Submission.generate_jobs <dpdispatcher.Submission.generate_jobs>` create
+jobs from tasks.
+
+## Minimal local submission
+
+The following example runs a shell task in the current directory without an HPC
+scheduler or file transfer:
+
+```python
+from pathlib import Path
+
+from dpdispatcher import Machine, Resources, Submission, Task
+
+work_root = Path.cwd()
+machine = Machine.load_from_dict(
+    {
+        "batch_type": "Shell",
+        "context_type": "LazyLocalContext",
+        "local_root": str(work_root),
+    }
+)
+resources = Resources(
+    number_node=1,
+    cpu_per_node=1,
+    gpu_per_node=0,
+    queue_name="",
+    group_size=1,
+)
+task = Task(
+    command="printf 'done\\n' > result.txt",
+    task_work_path=".",
+    backward_files=["result.txt"],
+    outlog="task.out",
+    errlog="task.err",
+)
+
+submission = Submission(
+    work_base=".",
+    machine=machine,
+    resources=resources,
+    task_list=[task],
+)
+submission.run_submission(check_interval=1, clean=False)
+```
+
+Use `clean=False` while debugging so the execution directory and generated
+scripts remain available for inspection. For remote contexts, the default
+`clean=True` removes the submission-specific remote directory after declared
+outputs have been downloaded.
+
+## Paths and file staging
+
+DPDispatcher resolves paths in layers:
+
+1. `machine.local_root` identifies the local project root.
+1. `submission.work_base` identifies the submission directory below that root.
+1. `task.task_work_path` identifies a task directory below `work_base`.
+1. `forward_files` and `backward_files` are resolved below the task directory.
+
+Files shared by every task belong in `forward_common_files` or
+`backward_common_files` on the submission. Keep task working paths relative;
+absolute task paths bypass the staging model and are not supported.
+
+{class}`~dpdispatcher.contexts.lazy_local_context.LazyLocalContext` runs in the
+existing local directory. {class}`~dpdispatcher.contexts.local_context.LocalContext`
+stages work into another directory on the same host. Remote contexts such as
+{class}`~dpdispatcher.contexts.ssh_context.SSHContext` stage files to a
+submission-specific directory below `machine.remote_root`.
+
+## Task grouping and parallelism
+
+`Resources.group_size` and `Resources.para_deg` control different layers:
+
+- `group_size` is the maximum number of tasks packed into one scheduler job.
+  A value of `0` places all tasks in one generated job.
+- `para_deg` controls how many tasks inside that generated job run concurrently.
+
+Start with both values set to `1`. Increase `group_size` to reduce scheduler
+overhead, and increase `para_deg` only when the allocated CPUs or GPUs can run
+multiple task commands safely.
+
+## Loading configuration
+
+The core objects accept dictionaries directly and provide JSON/YAML loaders:
+
+```python
+machine = Machine.load_from_json("machine.json")
+resources = Resources.load_from_yaml("resources.yaml")
+task = Task.load_from_dict(task_config)
+```
+
+All loaders normalize and validate configuration with `dargs`. External `$ref`
+resolution is disabled by default because it reads additional local files. Pass
+`allow_ref=True` only for trusted configuration:
+
+```python
+task = Task.load_from_json("task.json", allow_ref=True)
+machine = Machine.load_from_dict(machine_config, allow_ref=True)
+resources = Resources.load_from_dict(resources_config, allow_ref=True)
+```
+
+:::{note}
+The `Machine` and `Resources` JSON/YAML convenience loaders currently load one
+file directly and do not expose `allow_ref`. Read trusted files into a mapping
+and use {meth}`Machine.load_from_dict <dpdispatcher.Machine.load_from_dict>` or
+{meth}`Resources.load_from_dict <dpdispatcher.Resources.load_from_dict>` when
+`$ref` resolution is required.
+:::
+
+## Submission lifecycle
+
+{meth}`Submission.run_submission <dpdispatcher.Submission.run_submission>`
+performs the complete lifecycle:
+
+1. Generate deterministic groups of jobs from the registered tasks.
+1. Recover compatible scheduler state from a previous run when available.
+1. Upload task files and generated scripts.
+1. Submit or resubmit jobs and poll their normalized status.
+1. Download declared results.
+1. Save recovery state and, by default, clean the execution directory.
+
+Important keyword arguments are:
+
+- `dry_run=True`: stage inputs and scripts without submitting jobs.
+- `exit_on_submit=True`: submit jobs and return without polling for completion.
+- `clean=False`: retain the execution directory after downloading results.
+- `check_interval=N`: poll scheduler status every `N` seconds.
+
+For concurrent submissions, use
+{meth}`Submission.async_run_submission <dpdispatcher.Submission.async_run_submission>`.
+The asynchronous wrapper runs the blocking lifecycle in an executor and defaults
+to `clean=False`, which avoids one submission removing files another operation
+may still need.
+
+## Extending DPDispatcher
+
+A new scheduler subclasses {class}`~dpdispatcher.Machine` and implements the
+scheduler-specific submission, status, script-header, and finish-tag methods. A
+new execution environment subclasses
+{class}`~dpdispatcher.base_context.BaseContext` and implements transfer,
+cleanup, file access, and command execution. Subclasses register automatically
+under their class name and aliases when imported.
+
+The generated {doc}`api/api` pages contain the complete module and method
+reference.

--- a/doc/resources.rst
+++ b/doc/resources.rst
@@ -1,7 +1,7 @@
 Resources parameters
 ======================================
 .. note::
-   One can load, modify, and export the input file by using our effective web-based tool `DP-GUI <https://dpgui.deepmodeling.com/input/dpdispatcher-resources>`_ online or hosted using the :ref:`command line interface <cli>` :code:`dpdisp gui`. All parameters below can be set in DP-GUI. By clicking "SAVE JSON", one can download the input file for.
+   One can load, modify, and export the input file by using our web-based tool `DP-GUI <https://dpgui.deepmodeling.com/input/dpdispatcher-resources>`_ online or host it using the :ref:`command line interface <cli>` command :code:`dpdisp gui`. All parameters below can be set in DP-GUI. Click "SAVE JSON" to download the input file.
 
 .. dargs::
    :module: dpdispatcher.arginfo

--- a/dpdispatcher/__init__.py
+++ b/dpdispatcher/__init__.py
@@ -1,3 +1,10 @@
+"""Public interface for configuring and running DPDispatcher submissions.
+
+The top-level package exports the core configuration and runtime objects. Batch
+systems and execution contexts register themselves when the package is imported,
+so :class:`Machine` can construct the requested backend from configuration.
+"""
+
 __author__ = "DeepModeling Team"
 __copyright__ = "Copyright 2019-2023, DeepModeling"
 __status__ = "Production"

--- a/dpdispatcher/arginfo.py
+++ b/dpdispatcher/arginfo.py
@@ -1,3 +1,5 @@
+"""Expose dargs schemas for machine, resource, and task configuration."""
+
 from dpdispatcher.machine import Machine
 from dpdispatcher.submission import Resources, Task
 

--- a/dpdispatcher/base_context.py
+++ b/dpdispatcher/base_context.py
@@ -1,3 +1,5 @@
+"""Define the execution-context interface used by machine backends."""
+
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
@@ -13,11 +15,12 @@ if TYPE_CHECKING:
 
 
 class BaseContext(metaclass=ABCMeta):
-    """Common interface and runtime attributes shared by execution contexts.
+    """Define file transfer and command execution for an environment.
 
-    Backend implementations historically return different auxiliary values
-    from transfer and cleanup operations. Those methods therefore use ``Any``
-    at this boundary while concrete contexts retain their precise return types.
+    ``BaseContext`` acts as both an abstract interface and a factory. Calling it
+    with ``context_type`` selects a registered subclass such as ``SSHContext``
+    or ``LazyLocalContext``. Concrete contexts must implement file transfer,
+    cleanup, file access, and blocking command execution.
     """
 
     subclasses_dict = {}
@@ -37,6 +40,7 @@ class BaseContext(metaclass=ABCMeta):
     machine: Machine
 
     def __new__(cls, *args: Any, **kwargs: Any) -> BaseContext:  # noqa: ANN401
+        """Select a registered context subclass when called on ``BaseContext``."""
         if cls is BaseContext:
             subcls = cls.subclasses_dict[kwargs["context_type"]]
             instance = subcls.__new__(subcls, *args, **kwargs)
@@ -56,6 +60,7 @@ class BaseContext(metaclass=ABCMeta):
 
     @classmethod
     def load_from_dict(cls, context_dict: dict[str, Any]) -> BaseContext:  # noqa: ANN401
+        """Create a registered context from a machine configuration mapping."""
         context_type = context_dict["context_type"]
         # print("debug778:context_type", cls.subclasses_dict, context_type)
         try:
@@ -69,10 +74,12 @@ class BaseContext(metaclass=ABCMeta):
         return context
 
     def bind_submission(self, submission: Submission) -> None:
+        """Bind a submission and its derived working paths to this context."""
         self.submission = submission
 
     @abstractmethod
     def upload(self, submission: Submission) -> None:
+        """Upload all files required by a submission to the execution root."""
         raise NotImplementedError("abstract method")
 
     @abstractmethod
@@ -83,18 +90,22 @@ class BaseContext(metaclass=ABCMeta):
         mark_failure: bool = True,
         back_error: bool = False,
     ) -> Any:  # noqa: ANN401
+        """Download declared result files from the execution root."""
         raise NotImplementedError("abstract method")
 
     @abstractmethod
     def clean(self) -> Any:  # noqa: ANN401
+        """Remove the submission-specific execution directory."""
         raise NotImplementedError("abstract method")
 
     @abstractmethod
     def write_file(self, fname: str, write_str: str) -> Any:  # noqa: ANN401
+        """Write text to a file relative to the execution root."""
         raise NotImplementedError("abstract method")
 
     @abstractmethod
     def read_file(self, fname: str) -> Any:  # noqa: ANN401
+        """Read text from a file relative to the execution root."""
         raise NotImplementedError("abstract method")
 
     def write_local_file(self, fname: str, write_str: str) -> Any:  # noqa: ANN401
@@ -107,6 +118,7 @@ class BaseContext(metaclass=ABCMeta):
         raise NotImplementedError("abstract method")
 
     def check_finish(self, proc: Any) -> Any:  # noqa: ANN401
+        """Return whether an asynchronous process has finished."""
         raise NotImplementedError("abstract method")
 
     def block_checkcall(

--- a/dpdispatcher/contexts/dp_cloud_server_context.py
+++ b/dpdispatcher/contexts/dp_cloud_server_context.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+"""Stage files for the legacy Bohrium cloud-service backend."""
+
 # %%
 from __future__ import annotations
 
@@ -32,6 +34,8 @@ DP_CLOUD_SERVER_HOME_DIR = os.path.join(
 
 
 class BohriumContext(BaseContext):
+    """Transfer submissions through Bohrium object storage and cloud APIs."""
+
     alias = ("DpCloudServerContext", "LebesgueContext")
 
     def __init__(

--- a/dpdispatcher/contexts/hdfs_context.py
+++ b/dpdispatcher/contexts/hdfs_context.py
@@ -1,3 +1,5 @@
+"""Stage DistributedShell submission data through HDFS archives."""
+
 import os
 import shutil
 import tarfile
@@ -14,6 +16,8 @@ if TYPE_CHECKING:
 
 
 class HDFSContext(BaseContext):
+    """Transfer submission inputs and outputs between local storage and HDFS."""
+
     def __init__(
         self,
         local_root: str,

--- a/dpdispatcher/contexts/lazy_local_context.py
+++ b/dpdispatcher/contexts/lazy_local_context.py
@@ -1,3 +1,5 @@
+"""Execute jobs directly inside their existing local working directory."""
+
 import os
 import subprocess as sp
 from typing import TYPE_CHECKING, Any
@@ -9,6 +11,8 @@ if TYPE_CHECKING:
 
 
 class SPRetObj:
+    """Adapt subprocess byte output to the stream interface used by contexts."""
+
     def __init__(self, ret: bytes) -> None:
         self.data = ret
 

--- a/dpdispatcher/contexts/local_context.py
+++ b/dpdispatcher/contexts/local_context.py
@@ -1,3 +1,5 @@
+"""Execute jobs locally while staging them in a separate directory."""
+
 from __future__ import annotations
 
 import os
@@ -18,6 +20,8 @@ if TYPE_CHECKING:
 
 
 class SPRetObj:
+    """Adapt subprocess byte output to the stream interface used by contexts."""
+
     def __init__(self, ret: bytes) -> None:
         self.data = ret
 

--- a/dpdispatcher/contexts/openapi_context.py
+++ b/dpdispatcher/contexts/openapi_context.py
@@ -1,3 +1,5 @@
+"""Stage submissions for Bohrium through its SDK-based OpenAPI."""
+
 from __future__ import annotations
 
 import glob
@@ -35,12 +37,13 @@ DP_CLOUD_SERVER_HOME_DIR = os.path.join(
 
 
 def unzip_file(zip_file: str, out_dir: str = "./") -> None:
-    """Extract an OpenAPI result zip without allowing unsafe members."""
+    """Extract a ZIP archive into a local directory."""
     with ZipFile(zip_file, "r") as obj:
         safe_extract_zip(obj, out_dir)
 
 
 def zip_file_list(root_path: str, zip_filename: str, file_list: list[str] = []) -> str:
+    """Create a ZIP archive from paths and glob patterns below a root."""
     out_zip_file = os.path.join(root_path, zip_filename)
     # print('debug: file_list', file_list)
     zip_obj = ZipFile(out_zip_file, "w")
@@ -65,6 +68,8 @@ def zip_file_list(root_path: str, zip_filename: str, file_list: list[str] = []) 
 
 
 class OpenAPIContext(BaseContext):
+    """Transfer files with Bohrium object storage authenticated by access key."""
+
     def __init__(
         self,
         local_root: str,

--- a/dpdispatcher/contexts/ssh_context.py
+++ b/dpdispatcher/contexts/ssh_context.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+"""Provide SSH command execution and rsync/SFTP file staging."""
+
 from __future__ import annotations
 
 import errno
@@ -39,6 +41,8 @@ if TYPE_CHECKING:
 
 
 class SSHSession:
+    """Manage a resilient Paramiko SSH connection and file-transfer helpers."""
+
     def __init__(
         self,
         hostname: str,
@@ -309,7 +313,7 @@ class SSHSession:
 
     @retry(sleep=1)
     def exec_command(self, cmd: str) -> tuple[Any, Any, Any]:  # noqa: ANN401
-        """Calling self.ssh.exec_command but has an exception check."""
+        """Call ``SSHClient.exec_command`` with connection checks and retries."""
         assert self.ssh is not None
         try:
             return self.ssh.exec_command(cmd)
@@ -464,6 +468,8 @@ class SSHSession:
 
 
 class SSHContext(BaseContext):
+    """Run submissions on a remote host reached through an SSH session."""
+
     def __init__(
         self,
         local_root: str,
@@ -969,6 +975,23 @@ class SSHContext(BaseContext):
         directories: list[str] | None = None,
         tar_compress: bool = True,
     ) -> None:
+        """Upload files to server.
+
+        Parameters
+        ----------
+        files : list
+            uploaded files
+        dereference : bool, default: True
+            If dereference is False, add symbolic and hard links to the archive.
+            If it is True, add the content of the target files to the archive.
+            This has no effect on systems that do not support symbolic links.
+        directories : list, default: None
+            uploaded directories non-recursively. Use `files` for uploading
+            recursively
+        tar_compress : bool, default: True
+            If tar_compress is True, compress the archive using gzip
+            It it is False, then it is uncompressed
+        """
         assert self.submission.submission_hash is not None
         """Upload files to server.
 

--- a/dpdispatcher/dlog.py
+++ b/dpdispatcher/dlog.py
@@ -1,3 +1,5 @@
+"""Configure the package logger for file and standard-output diagnostics."""
+
 import logging
 import os
 import sys

--- a/dpdispatcher/dpcloudserver/__init__.py
+++ b/dpdispatcher/dpcloudserver/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility package for the legacy DP cloud-server integration."""

--- a/dpdispatcher/dpdisp.py
+++ b/dpdispatcher/dpdisp.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+"""Implement the ``dpdisp`` command-line interface."""
+
 import argparse
 
 from dpdispatcher.entrypoints.gui import start_dpgui
@@ -157,6 +159,7 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
 
 
 def main() -> None:
+    """Parse command-line arguments and dispatch the selected subcommand."""
     args = parse_args()
     if args.command == "submission":
         handle_submission(

--- a/dpdispatcher/entrypoints/run.py
+++ b/dpdispatcher/entrypoints/run.py
@@ -4,6 +4,7 @@ from dpdispatcher.run import run_pep723
 
 
 def run(*, filename: str, allow_ref: bool = False) -> None:
+    """Read and execute a Python script containing DPDispatcher metadata."""
     with open(filename) as f:
         script = f.read()
     run_pep723(script, allow_ref=allow_ref)

--- a/dpdispatcher/entrypoints/submission.py
+++ b/dpdispatcher/entrypoints/submission.py
@@ -1,3 +1,5 @@
+"""Implement recovery actions for a recorded submission."""
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -1,3 +1,5 @@
+"""Define scheduler-independent job generation and the machine factory."""
+
 from __future__ import annotations
 
 import json
@@ -213,12 +215,20 @@ def _format_export_lines(envs: Mapping[str, Any]) -> str:
 
 
 class Machine(metaclass=ABCMeta):
-    """A machine is used to handle the connection with remote machines.
+    """Generate, submit, and monitor jobs on a selected batch system.
+
+    ``Machine`` acts as a factory when instantiated with ``batch_type``. A
+    machine delegates filesystem and command operations to its bound
+    :class:`~dpdispatcher.base_context.BaseContext` while its concrete subclass
+    implements scheduler-specific submission and status handling.
 
     Parameters
     ----------
-    context : SubClass derived from BaseContext
-        The context is used to mainatin the connection with remote machine.
+    context : BaseContext, optional
+        Existing execution context. When omitted, ``context_type`` and the root
+        and profile arguments are used to construct one.
+    retry_count : int, default=3
+        Number of scheduler failures allowed before a job is reported as failed.
     """
 
     subclasses_dict = {}
@@ -228,6 +238,7 @@ class Machine(metaclass=ABCMeta):
     alias: tuple[str, ...] = tuple()
 
     def __new__(cls, *args: Any, **kwargs: Any) -> Machine:  # noqa: ANN401
+        """Select a registered backend subclass when called on ``Machine``."""
         if cls is Machine:
             subcls = cls.subclasses_dict[kwargs["batch_type"]]
             instance = subcls.__new__(subcls, *args, **kwargs)
@@ -260,6 +271,7 @@ class Machine(metaclass=ABCMeta):
         self.retry_count = retry_count
 
     def bind_context(self, context: BaseContext) -> None:
+        """Bind the execution context used for files and remote commands."""
         self.context = context
 
     def get_job_error(self, job: Job) -> str | None:
@@ -297,6 +309,7 @@ class Machine(metaclass=ABCMeta):
 
     @classmethod
     def load_from_json(cls, json_path: str) -> Machine:
+        """Load a machine configuration from a JSON file."""
         with open(json_path) as f:
             machine_dict = json.load(f)
         machine = cls.load_from_dict(machine_dict=machine_dict)
@@ -304,6 +317,7 @@ class Machine(metaclass=ABCMeta):
 
     @classmethod
     def load_from_yaml(cls, yaml_path: str) -> Machine:
+        """Load a machine configuration from a YAML file."""
         with open(yaml_path) as f:
             machine_dict = yaml.safe_load(f)
         machine = cls.load_from_dict(machine_dict=machine_dict)
@@ -347,6 +361,7 @@ class Machine(metaclass=ABCMeta):
         return machine
 
     def serialize(self, if_empty_remote_profile: bool = False) -> dict[str, Any]:  # noqa: ANN401
+        """Return a normalized dictionary representation of the machine."""
         machine_dict = {}
         machine_dict["batch_type"] = self.__class__.__name__
         machine_dict["context_type"] = self.context.__class__.__name__
@@ -374,26 +389,31 @@ class Machine(metaclass=ABCMeta):
 
     @classmethod
     def deserialize(cls, machine_dict: dict[str, Any]) -> Machine:  # noqa: ANN401
+        """Reconstruct a machine from its serialized dictionary."""
         machine = cls.load_from_dict(machine_dict=machine_dict)
         return machine
 
     @abstractmethod
     def check_status(self, job: Job) -> JobStatus:
+        """Query the scheduler and return the current status of a job."""
         raise NotImplementedError(
             "abstract method check_status should be implemented by derived class"
         )
 
     def default_resources(self, res: Resources) -> Resources:
+        """Return backend defaults for an incomplete resource specification."""
         raise NotImplementedError(
             "abstract method default_resources should be implemented by derived class"
         )
 
     def sub_script_head(self, res: Resources) -> str:
+        """Return the legacy scheduler header for a resource specification."""
         raise NotImplementedError(
             "abstract method sub_script_head should be implemented by derived class"
         )
 
     def sub_script_cmd(self, res: Resources) -> str:
+        """Return the legacy scheduler launch command for resources."""
         raise NotImplementedError(
             "abstract method sub_script_cmd should be implemented by derived class"
         )
@@ -406,9 +426,11 @@ class Machine(metaclass=ABCMeta):
         )
 
     def gen_script_run_command(self, job: Job) -> str:
+        """Return the command that sources the generated per-task script."""
         return f"source $REMOTE_ROOT/{job.script_file_name}.run"
 
     def gen_script(self, job: Job) -> str:
+        """Generate the complete scheduler submission script for a job."""
         script_header = self.gen_script_header(job)
         script_custom_flags = self.gen_script_custom_flags_lines(job)
         script_env = self.gen_script_env(job)
@@ -424,6 +446,7 @@ class Machine(metaclass=ABCMeta):
         return script
 
     def check_if_recover(self, submission: Submission) -> bool:
+        """Return whether serialized state exists for a remote submission."""
         submission_hash = submission.submission_hash
         submission_file_name = f"{submission_hash}.json"
         if_recover = self.context.check_file_exists(submission_file_name)
@@ -431,17 +454,20 @@ class Machine(metaclass=ABCMeta):
 
     @abstractmethod
     def check_finish_tag(self, job: Job) -> bool:
+        """Return whether the success marker for a job is present."""
         raise NotImplementedError(
             "abstract method check_finish_tag should be implemented by derived class"
         )
 
     @abstractmethod
     def gen_script_header(self, job: Job) -> str:
+        """Generate scheduler directives and the script shebang for a job."""
         raise NotImplementedError(
             "abstract method gen_script_header should be implemented by derived class"
         )
 
     def gen_script_custom_flags_lines(self, job: Job) -> str:
+        """Render user-provided scheduler directives as script lines."""
         custom_flags_lines = ""
         custom_flags = job.resources.custom_flags
         for ii in custom_flags:
@@ -450,6 +476,7 @@ class Machine(metaclass=ABCMeta):
         return custom_flags_lines
 
     def gen_script_env(self, job: Job) -> str:
+        """Generate environment setup shared by every task in a job."""
         source_files_part = ""
 
         module_unload_part = ""
@@ -505,6 +532,7 @@ class Machine(metaclass=ABCMeta):
         return script_env
 
     def gen_script_command(self, job: Job) -> str:
+        """Generate task commands, logging redirection, and completion tags."""
         script_command = ""
         resources = job.resources
         # in_para_task_num = 0
@@ -552,6 +580,7 @@ class Machine(metaclass=ABCMeta):
         )
 
     def gen_script_end(self, job: Job) -> str:
+        """Generate job finalization, failure checks, and append commands."""
         job_tag_finished = job.job_hash + "_job_tag_finished"
         flag_if_job_task_fail = job.job_hash + "_flag_if_job_task_fail"
 
@@ -568,6 +597,7 @@ class Machine(metaclass=ABCMeta):
     def gen_script_wait(self, resources: Resources) -> str:
         # if not resources.strategy.get('if_cuda_multi_devices', None):
         #     return "wait \n"
+        """Generate synchronization commands for the configured parallelism."""
         para_deg = resources.para_deg
         resources.task_in_para += 1
         # task_need_gpus = task.task_need_gpus
@@ -586,6 +616,7 @@ class Machine(metaclass=ABCMeta):
     def gen_command_env_cuda_devices(self, resources: Resources) -> str:
         # task_need_resources = task.task_need_resources
         # task_need_gpus = task_need_resources.get('task_need_gpus', 1)
+        """Assign a GPU to the next task when automatic GPU mapping is enabled."""
         command_env = ""
         # gpu_number = resources.gpu_per_node
         # resources.gpu_in_use = 0
@@ -602,6 +633,7 @@ class Machine(metaclass=ABCMeta):
     @classmethod
     def arginfo(cls) -> Argument:
         # TODO: change the possible value of batch and context types after we refactor the code
+        """Build the dargs schema for machine and context configuration."""
         doc_batch_type = "Batch backend used to execute jobs. Option: " + ", ".join(
             cls.options
         )

--- a/dpdispatcher/machines/JH_UniScheduler.py
+++ b/dpdispatcher/machines/JH_UniScheduler.py
@@ -1,3 +1,5 @@
+"""Implement job submission through JH UniScheduler commands."""
+
 from __future__ import annotations
 
 import shlex

--- a/dpdispatcher/machines/distributed_shell.py
+++ b/dpdispatcher/machines/distributed_shell.py
@@ -1,3 +1,5 @@
+"""Implement Hadoop YARN DistributedShell submission."""
+
 from typing import TYPE_CHECKING
 
 from dpdispatcher.dlog import dlog
@@ -55,6 +57,8 @@ fi
 
 
 class DistributedShell(Machine):
+    """Run archived DPDispatcher jobs in a YARN DistributedShell container."""
+
     def gen_script_env(self, job: "Job") -> str:
         source_files_part = ""
 

--- a/dpdispatcher/machines/dp_cloud_server.py
+++ b/dpdispatcher/machines/dp_cloud_server.py
@@ -1,3 +1,5 @@
+"""Implement the legacy Bohrium cloud-service batch backend."""
+
 import os
 import shutil
 import time
@@ -22,6 +24,8 @@ shell_script_header_template = """
 
 
 class Bohrium(Machine):
+    """Submit jobs through the legacy Bohrium API and object storage."""
+
     alias = ("Lebesgue", "DpCloudServer")
 
     def __init__(self, context: "BaseContext", **kwargs: Any) -> None:  # noqa: ANN401

--- a/dpdispatcher/machines/fugaku.py
+++ b/dpdispatcher/machines/fugaku.py
@@ -1,3 +1,5 @@
+"""Implement Fujitsu Fugaku-compatible scheduler submission."""
+
 import shlex
 from typing import TYPE_CHECKING
 
@@ -17,6 +19,8 @@ fugaku_script_header_template = """\
 
 
 class Fugaku(Machine):
+    """Generate and submit jobs using Fujitsu's ``pjsub`` interface."""
+
     def gen_script(self, job: "Job") -> str:
         fugaku_script = super().gen_script(job)
         return fugaku_script

--- a/dpdispatcher/machines/lsf.py
+++ b/dpdispatcher/machines/lsf.py
@@ -1,3 +1,5 @@
+"""Implement IBM Spectrum LSF scheduler submission."""
+
 from __future__ import annotations
 
 import shlex

--- a/dpdispatcher/machines/openapi.py
+++ b/dpdispatcher/machines/openapi.py
@@ -1,3 +1,5 @@
+"""Implement the SDK-based Bohrium OpenAPI batch backend."""
+
 import os
 import shutil
 import time
@@ -30,12 +32,14 @@ shell_script_header_template = """
 
 
 def unzip_file(zip_file: str, out_dir: str = "./") -> None:
-    """Extract an OpenAPI result zip without allowing unsafe members."""
+    """Extract a ZIP archive into a local directory."""
     with ZipFile(zip_file, "r") as obj:
         safe_extract_zip(obj, out_dir)
 
 
 class OpenAPI(Machine):
+    """Submit and monitor jobs through the Bohrium SDK OpenAPI."""
+
     def __init__(self, context: "BaseContext", **kwargs: Any) -> None:  # noqa: ANN401
         super().__init__(context=context, **kwargs)
         if not found_bohriumsdk:

--- a/dpdispatcher/machines/pbs.py
+++ b/dpdispatcher/machines/pbs.py
@@ -1,3 +1,5 @@
+"""Implement PBS-family schedulers, including Torque and SGE variants."""
+
 from __future__ import annotations
 
 import posixpath
@@ -25,6 +27,7 @@ pbs_script_header_template = """
 class PBS(Machine):
     # def __init__(self, **kwargs):
     #     super().__init__(**kwargs)
+    """Submit and monitor jobs through OpenPBS or PBS Professional."""
 
     def gen_script(self, job: Job) -> str:
         pbs_script = super().gen_script(job)
@@ -130,6 +133,8 @@ class PBS(Machine):
 
 
 class Torque(PBS):
+    """Adapt PBS submission and status parsing for the Torque scheduler."""
+
     def check_status(self, job: Job) -> JobStatus:
         job_id = str(job.job_id)
         if job_id == "":
@@ -201,6 +206,8 @@ sge_script_header_template = """
 
 
 class SGE(PBS):
+    """Adapt PBS-style scripts and commands for Sun Grid Engine."""
+
     def __init__(self, **kwargs: Any) -> None:  # noqa: ANN401
         super().__init__(**kwargs)
 

--- a/dpdispatcher/machines/shell.py
+++ b/dpdispatcher/machines/shell.py
@@ -1,3 +1,5 @@
+"""Implement local or remote background execution through a shell."""
+
 import shlex
 from typing import TYPE_CHECKING
 
@@ -15,6 +17,8 @@ shell_script_header_template = """
 
 
 class Shell(Machine):
+    """Run generated job scripts as background shell processes."""
+
     def gen_script(self, job: "Job") -> str:
         shell_script = super().gen_script(job)
         return shell_script

--- a/dpdispatcher/machines/slurm.py
+++ b/dpdispatcher/machines/slurm.py
@@ -1,3 +1,5 @@
+"""Implement Slurm scheduler submission and Slurm job arrays."""
+
 from __future__ import annotations
 
 import math
@@ -34,6 +36,8 @@ wait
 
 
 class Slurm(Machine):
+    """Submit and monitor jobs through Slurm command-line tools."""
+
     def gen_script(self, job: Job) -> str:
         slurm_script = super().gen_script(job)
         return slurm_script

--- a/dpdispatcher/run.py
+++ b/dpdispatcher/run.py
@@ -1,3 +1,5 @@
+"""Parse PEP 723 metadata and execute its DPDispatcher submission."""
+
 import os
 import re
 import sys

--- a/dpdispatcher/submission.py
+++ b/dpdispatcher/submission.py
@@ -1,4 +1,6 @@
 # %%
+"""Define submissions, tasks, generated jobs, and resource requests."""
+
 import asyncio
 import copy
 import functools
@@ -28,25 +30,26 @@ default_strategy = dict(if_cuda_multi_devices=False, ratio_unfinished=0.0)
 
 
 class Submission:
-    """A submission represents a collection of tasks.
-    These tasks usually locate at a common directory.
-    And these Tasks may share common files to be uploaded and downloaded.
+    """Coordinate a collection of tasks that share a working directory.
+
+    A submission groups tasks into scheduler jobs, stages common files, monitors
+    execution, downloads declared results, and records state for recovery.
 
     Parameters
     ----------
-    work_base : Path
-        the base directory of the local tasks. It is usually the dir name of project .
-    machine : Machine
-        machine class object (for example, PBS, Slurm, Shell) to execute the jobs.
-        The machine can still be bound after the instantiation with the bind_submission method.
-    resources : Resources
-        the machine resources (cpu or gpu) used to generate the slurm/pbs script
-    forward_common_files : list
-        the common files to be uploaded to other computers before the jobs begin
-    backward_common_files : list
-        the common files to be downloaded from other computers after the jobs finish
-    task_list : list of Task
-        a list of tasks to be run.
+    work_base : path-like
+        Local base directory containing all task working directories.
+    machine : Machine, optional
+        Batch backend and execution context. It may be bound later with
+        :meth:`bind_machine`.
+    resources : Resources, optional
+        Resource request copied into every generated job.
+    forward_common_files : list of path-like, optional
+        Files shared by all tasks and staged before execution.
+    backward_common_files : list of path-like, optional
+        Shared result files downloaded after execution.
+    task_list : list of Task, optional
+        Tasks to register when the submission is created.
     """
 
     def __init__(
@@ -87,8 +90,9 @@ class Submission:
         return json.dumps(self.serialize(), indent=4)
 
     def __eq__(self, other: object) -> bool:
-        """When check whether the two submission are equal,
-        we disregard the runtime infomation(job_state, job_id, fail_count) of the submission.belonging_jobs.
+        """Compare submissions while ignoring mutable job runtime information.
+
+        Job state, scheduler IDs, and failure counts do not affect equality.
         """
         return json.dumps(self.serialize(if_static=True)) == json.dumps(
             other.serialize(if_static=True)  # type: ignore[attr-defined]
@@ -105,22 +109,19 @@ class Submission:
         *,
         bind_context: bool = True,
     ) -> "Submission":  # noqa: ANN401
-        """Convert the submission_dict to a Submission class object.
+        """Reconstruct a submission from serialized state.
 
         Parameters
         ----------
         submission_dict : dict
-            path-like, the base directory of the local tasks
-        machine : Machine
-            Machine class Object to execute the jobs
-        bind_context : bool, default=True
-            Whether to bind the machine context to the deserialized submission.
-            Disable this when the machine is shared with an active submission.
+            Serialized submission configuration and job state.
+        machine : Machine, optional
+            Machine to bind instead of reconstructing the serialized machine.
 
         Returns
         -------
-        submission : Submission
-            the Submission class instance converted from the submission_dict
+        Submission
+            Reconstructed submission.
         """
         submission = cls(
             work_base=submission_dict["work_base"],
@@ -143,17 +144,17 @@ class Submission:
         return submission
 
     def serialize(self, if_static: bool = False) -> dict[str, Any]:  # noqa: ANN401
-        """Convert the Submission class instance to a dictionary.
+        """Return a JSON-compatible representation of the submission.
 
         Parameters
         ----------
-        if_static : bool
-            whether dump the job runtime infomation (like job_id, job_state, fail_count) to the dictionary.
+        if_static : bool, default=False
+            Exclude job IDs, states, and failure counts when true.
 
         Returns
         -------
-        submission_dict : dict
-            the dictionary converted from the Submission class instance
+        dict
+            Submission configuration and, unless excluded, current runtime state.
         """
         assert self.resources is not None
         submission_dict = {}
@@ -178,6 +179,7 @@ class Submission:
         return submission_dict
 
     def register_task(self, task: "Task") -> None:
+        """Append one task before jobs have been generated."""
         if self.belonging_jobs:
             raise RuntimeError(
                 f"Not allowed to register tasks after generating jobs. submission hash error {self}"
@@ -185,6 +187,7 @@ class Submission:
         self.belonging_tasks.append(task)
 
     def register_task_list(self, task_list: list["Task"]) -> None:
+        """Append multiple tasks before jobs have been generated."""
         if self.belonging_jobs:
             raise RuntimeError(
                 f"Not allowed to register tasks after generating jobs. submission hash error {self}"
@@ -192,6 +195,7 @@ class Submission:
         self.belonging_tasks.extend(task_list)
 
     def get_hash(self) -> str:
+        """Return the stable hash of the submission's static configuration."""
         return sha1(
             json.dumps(self.serialize(if_static=True)).encode("utf-8")
         ).hexdigest()
@@ -202,14 +206,17 @@ class Submission:
         *,
         bind_context: bool = True,
     ) -> "Submission":
-        """Bind this submission to a machine. update the machine's context remote_root and local_root.
+        """Bind a machine and initialize submission-specific context paths.
 
         Parameters
         ----------
-        machine : Machine
-            the machine to bind with
-        bind_context : bool, default=True
-            Whether to update the machine context's active submission and roots.
+        machine : Machine or None
+            Machine to use for generated jobs and file operations.
+
+        Returns
+        -------
+        Submission
+            This submission, for convenient chained configuration.
         """
         self.submission_hash = self.get_hash()
         self.machine = machine
@@ -235,32 +242,27 @@ class Submission:
         clean: bool | str = True,
         check_interval: int = 30,
     ) -> dict[str, Any]:  # noqa: ANN401
-        """Main method to execute the submission.
-        First, check whether old Submission exists on the remote machine, and try to recover from it.
-        Second, upload the local files to the remote machine where the tasks to be executed.
-        Third, run the submission defined previously.
-        Forth, wait until the tasks in the submission finished and download the result file to local directory.
-        If dry_run is True, submission will be uploaded but not be executed and exit.
-        If exit_on_submit is True, submission will exit.
+        """Execute the submission and monitor it until completion.
+
+        The lifecycle recovers compatible state, stages files, submits or retries
+        jobs, polls their status, downloads declared results, persists recovery
+        state, and optionally cleans the execution directory.
 
         Parameters
         ----------
-        dry_run : bool
-            If True, only upload without execution.
+        dry_run : bool, default=False
+            Upload inputs and generated scripts without submitting jobs.
+        exit_on_submit : bool, default=False
+            Return after jobs have been submitted instead of waiting for them.
+        clean : bool, default=True
+            Remove the submission-specific execution directory after download.
+        check_interval : int or float, default=30
+            Seconds between scheduler status checks.
 
-        exit_on_submit : bool
-            If True, exit after submission without waiting.
-
-        clean : bool or str
-            Controls whether to clean remote working directory after completion.
-
-            - True or "always": always clean (default, backward compatible)
-            - False or "never": never clean
-            - "on_success": only clean when all jobs finished successfully;
-              preserve remote workdir on failure for debugging.
-
-        check_interval : int
-            Seconds between status polling iterations.
+        Returns
+        -------
+        dict
+            Serialized submission state at the point this method returns.
         """
         assert self.resources is not None
         machine = self._require_machine()
@@ -424,15 +426,7 @@ class Submission:
                     )
 
     def try_download_result(self) -> bool:
-        """Download result files, retrying transient failures for up to 24 hours.
-
-        Returns
-        -------
-        bool
-            Whether all result files were downloaded successfully. A false
-            result prevents ``clean='on_success'`` from deleting the only
-            remaining remote copy after retry exhaustion.
-        """
+        """Download results, retrying transient failures for up to 24 hours."""
         start_time = time.time()
         retry_interval = 60  # retry every 1 minute
         success = False
@@ -459,32 +453,22 @@ class Submission:
         return success
 
     async def async_run_submission(self, **kwargs: Any) -> None:  # noqa: ANN401
-        """Async interface of run_submission.
+        """Run :meth:`run_submission` in an executor.
+
+        Cleanup defaults to false for asynchronous submissions so concurrent
+        work does not remove shared context data unexpectedly. Explicitly pass
+        ``clean=True`` only when each submission has an isolated execution root.
 
         Examples
         --------
         >>> import asyncio
-        >>> from dpdispacher import Machine, Resource, Submission
-        >>> async def run_jobs():
-        ...     backgroud_task = set()
-        ...     # task1
-        ...     task1 = Task(...)
-        ...     submission1 = Submission(..., task_list=[task1])
-        ...     background_task = asyncio.create_task(
-        ...         submission1.async_run_submission(check_interval=2, clean=False)
+        >>> async def run_all(submissions):
+        ...     return await asyncio.gather(
+        ...         *(
+        ...             submission.async_run_submission(check_interval=2)
+        ...             for submission in submissions
+        ...         )
         ...     )
-        ...     # task2
-        ...     task2 = Task(...)
-        ...     submission2 = Submission(..., task_list=[task1])
-        ...     background_task = asyncio.create_task(
-        ...         submission2.async_run_submission(check_interval=2, clean=False)
-        ...     )
-        ...     background_tasks.add(background_task)
-        ...     result = await asyncio.gather(*background_tasks)
-        ...     return result
-        >>> run_jobs()
-
-        May raise Error if pass `clean=True` explicitly when submit to pbs or slurm.
         """
         kwargs = {**{"clean": False}, **kwargs}
         if self._should_clean(kwargs["clean"]):
@@ -497,11 +481,11 @@ class Submission:
         return await loop.run_in_executor(None, wrapped_submission)
 
     def update_submission_state(self) -> None:
-        """Check whether all the jobs in the submission.
+        """Refresh every unfinished job's state from its machine backend.
 
         Notes
         -----
-        this method will not handle unexpected (like resubmit terminated) job state in the submission.
+        This method only queries state. It does not submit or retry jobs.
         """
         for job in self.belonging_jobs:
             if job.job_state == JobStatus.finished:
@@ -513,10 +497,10 @@ class Submission:
             )
 
     def handle_unexpected_submission_state(self) -> None:
-        """Handle unexpected job state of the submission.
-        If the job state is unsubmitted, submit the job.
-        If the job state is terminated (killed unexpectly), resubmit the job.
-        If the job state is unknown, raise an error.
+        """Submit unsubmitted jobs and retry unexpectedly terminated jobs.
+
+        Unknown states and exhausted retries are persisted for recovery before
+        the error is propagated.
         """
         machine = self._require_machine()
         try:
@@ -535,17 +519,17 @@ class Submission:
             ) from e
 
     def check_ratio_unfinished(self, ratio_unfinished: float) -> bool:
-        """Calculate the ratio of unfinished tasks in the submission.
+        """Return whether the allowed unfinished-task threshold is satisfied.
 
         Parameters
         ----------
         ratio_unfinished : float
-            the ratio of unfinished tasks in the submission
+            Maximum fraction of tasks that may remain unfinished.
 
         Returns
         -------
         bool
-            whether the ratio of unfinished tasks in the submission is larger than ratio_unfinished
+            True when the finished fraction is at least ``1 - ratio_unfinished``.
         """
         assert self.resources is not None
         machine = self._require_machine()
@@ -562,6 +546,7 @@ class Submission:
         return finished_num / len(self.belonging_tasks) >= (1 - ratio_unfinished)
 
     def remove_unfinished_tasks(self) -> None:
+        """Kill unfinished jobs and retain only tasks that already completed."""
         machine = self._require_machine()
         dlog.info("Remove unfinished tasks")
         # kill all jobs and mark them as finished
@@ -586,11 +571,11 @@ class Submission:
             ]
 
     def check_all_finished(self) -> bool:
-        """Check whether all the jobs in the submission.
+        """Return whether every generated job has finished successfully.
 
         Notes
         -----
-        This method will not handle unexpected job state in the submission.
+        This method does not submit, retry, or otherwise change job states.
         """
         # self.update_submission_state()
         if any(
@@ -617,11 +602,11 @@ class Submission:
             return True
 
     def generate_jobs(self) -> None:
-        """After tasks register to the self.belonging_tasks,
-        This method generate the jobs and add these jobs to self.belonging_jobs.
-        The jobs are generated by the tasks randomly, and there are self.resources.group_size tasks in a task.
-        Why we randomly shuffle the tasks is under the consideration of load balance.
-        The random seed is a constant (to be concrete, 42). And this insures that the jobs are equal when we re-run the program.
+        """Generate jobs after tasks are registered.
+
+        Tasks are shuffled with a fixed seed before grouping to distribute task
+        cost while preserving deterministic job hashes for recovery. Each job
+        contains at most ``resources.group_size`` tasks; zero groups all tasks.
         """
         assert self.resources is not None
         if self.belonging_jobs:
@@ -660,21 +645,25 @@ class Submission:
         self.submission_hash = self.get_hash()
 
     def upload_jobs(self) -> None:
+        """Upload submission inputs through the bound context."""
         self._require_machine().context.upload(self)
 
     def download_jobs(self) -> None:
+        """Download declared submission outputs through the bound context."""
         self._require_machine().context.download(self)
         # for job in self.belonging_jobs:
         #     job.tag_finished()
         # self.machine.context.write_file(self.machine.finish_tag_name, write_str="")
 
     def clean_jobs(self) -> None:
+        """Remove remote working data and the local recovery record."""
         self._require_machine().context.clean()
         assert self.submission_hash is not None
         record.remove(self.submission_hash)
 
     def submission_to_json(self) -> None:
         # self.update_submission_state()
+        """Write current submission state to the execution root as JSON."""
         write_str = json.dumps(self.serialize(), indent=4, default=str)
         submission_file_name = f"{self.submission_hash}.json"
         self._require_machine().context.write_file(
@@ -685,12 +674,14 @@ class Submission:
     def submission_from_json(
         cls, json_file_name: str = "submission.json"
     ) -> "Submission":
+        """Load a submission, including machine state, from a local JSON file."""
         with open(json_file_name) as f:
             submission_dict = json.load(f)
         submission = cls.deserialize(submission_dict=submission_dict, machine=None)
         return submission
 
     def try_recover_from_json(self) -> None:
+        """Restore compatible job state from the remote submission JSON file."""
         machine = self._require_machine()
         submission_file_name = f"{self.submission_hash}.json"
         if_recover = machine.context.check_file_exists(submission_file_name)
@@ -728,23 +719,24 @@ class Submission:
 
 
 class Task:
-    """A task is a sequential command to be executed,
-    as well as the files it depends on to transmit forward and backward.
+    """Represent a sequential command and its staged files.
+
+    A task records the files it depends on and the results to transfer back.
 
     Parameters
     ----------
-    command : Str
-        the command to be executed.
-    task_work_path : Path
-        the directory of each file where the files are dependent on.
-    forward_files : list of Path
-        the files to be transmitted to remote machine before the command execute.
-    backward_files : list of Path
-        the files to be transmitted from remote machine after the comand finished.
-    outlog : Str or None
-        the filename to which command redirect stdout
-    errlog : Str or None
-        the filename to which command redirects stderr, or None to inherit stderr
+    command : str
+        Shell command to execute.
+    task_work_path : path-like
+        Working directory relative to the submission's ``work_base``.
+    forward_files : list of path-like, optional
+        Task-specific input files staged before execution.
+    backward_files : list of path-like, optional
+        Task-specific result files downloaded after execution.
+    outlog : str or None, default="log"
+        File that receives standard output, or ``None`` to leave it attached.
+    errlog : str or None, default="err"
+        File that receives standard error, or ``None`` to leave it attached.
     """
 
     def __init__(
@@ -781,6 +773,7 @@ class Task:
         return self.serialize()[key]
 
     def get_hash(self) -> str:
+        """Return the stable hash of the task configuration."""
         return sha1(json.dumps(self.serialize()).encode("utf-8")).hexdigest()
 
     @classmethod
@@ -840,22 +833,23 @@ class Task:
 
     @classmethod
     def deserialize(cls, task_dict: dict[str, Any]) -> "Task":  # noqa: ANN401
-        """Convert the task_dict to a Task class object.
+        """Reconstruct a task from a serialized dictionary.
 
         Parameters
         ----------
         task_dict : dict
-            the dictionary which contains the task information
+            Task configuration.
 
         Returns
         -------
-        task : Task
-            the Task class instance converted from the task_dict
+        Task
+            Reconstructed task.
         """
         task = cls(**task_dict)
         return task
 
     def serialize(self) -> dict[str, Any]:  # noqa: ANN401
+        """Return the task configuration as a JSON-compatible dictionary."""
         task_dict = {}
         task_dict["command"] = self.command
         task_dict["task_work_path"] = self.task_work_path
@@ -868,6 +862,7 @@ class Task:
 
     @staticmethod
     def arginfo() -> Argument:
+        """Build the dargs schema for task configuration."""
         doc_command = (
             "Shell command executed for this task. A zero exit code is treated as success. "
             "If the real application may fail before useful artifacts are synchronized, consider "
@@ -958,18 +953,20 @@ class Task:
 
 
 class Job:
-    """Job is generated by Submission automatically.
-    A job ususally has many tasks and it may request computing resources from job scheduler systems.
-    Each Job can generate a script file to be submitted to the job scheduler system or executed locally.
+    """Represent one scheduler job generated from a group of tasks.
+
+    Applications normally let :class:`Submission` create jobs. A job owns a
+    resource request, generates scheduler scripts through its machine, and
+    stores scheduler ID, state, and retry information for recovery.
 
     Parameters
     ----------
     job_task_list : list of Task
-        the tasks belonging to the job
+        Tasks grouped into this scheduler job.
     resources : Resources
-        the machine resources. Passed from Submission when it constructs jobs.
-    machine : machine
-        machine object to execute the job. Passed from Submission when it constructs jobs.
+        Resource request copied from the parent submission.
+    machine : Machine, optional
+        Backend used to generate, submit, and monitor the job.
     """
 
     def __init__(
@@ -1000,8 +997,9 @@ class Job:
         return str(self.serialize())
 
     def __eq__(self, other: object) -> bool:
-        """When check whether the two jobs are equal,
-        we disregard the runtime infomation(job_state, job_id, fail_count) of the jobs.
+        """Compare jobs while ignoring mutable scheduler runtime information.
+
+        Job state, scheduler IDs, and failure counts do not affect equality.
         """
         return json.dumps(self.serialize(if_static=True)) == json.dumps(
             other.serialize(if_static=True)  # type: ignore[attr-defined]
@@ -1011,19 +1009,19 @@ class Job:
     def deserialize(
         cls, job_dict: dict[str, Any], machine: Optional["Machine"] = None
     ) -> "Job":  # noqa: ANN401
-        """Convert the  job_dict to a Submission class object.
+        """Reconstruct a job and its tasks from serialized state.
 
         Parameters
         ----------
         job_dict : dict
-            the dictionary which contains the job information
-        machine : Machine
-            the machine object to execute the job
+            Single-entry mapping from job hash to configuration and runtime data.
+        machine : Machine, optional
+            Machine to bind to the reconstructed job.
 
         Returns
         -------
-        submission : Job
-            the Job class instance converted from the job_dict
+        Job
+            Reconstructed job.
         """
         if len(job_dict.keys()) != 1:
             raise RuntimeError(
@@ -1053,11 +1051,11 @@ class Job:
         return job
 
     def get_job_state(self) -> None:
-        """Get the jobs. Usually, this method will query the database of slurm or pbs job scheduler system and get the results.
+        """Query the backend and update this job and its unfinished tasks.
 
         Notes
         -----
-        this method will not submit or resubmit the jobs if the job is unsubmitted.
+        This method does not submit or retry the job.
         """
         dlog.debug(
             f"query database; self.job_hash:{self.job_hash}; self.job_id:{self.job_id}"
@@ -1072,6 +1070,7 @@ class Job:
                 task.task_state = job_state
 
     def handle_unexpected_job_state(self) -> None:
+        """Submit or retry a job according to its current state."""
         job_state = self.job_state
 
         if job_state == JobStatus.unknown:
@@ -1127,20 +1126,21 @@ class Job:
             # self.get_job_state()
 
     def get_hash(self) -> str:
+        """Return the stable hash used as this job's identifier."""
         return str(list(self.serialize(if_static=True).keys())[0])
 
     def serialize(self, if_static: bool = False) -> dict[str, Any]:  # noqa: ANN401
-        """Convert the Task class instance to a dictionary.
+        """Return a hash-keyed, JSON-compatible representation of the job.
 
         Parameters
         ----------
-        if_static : bool
-            whether dump the job runtime infomation (job_id, job_state, fail_count, job_uuid etc.) to the dictionary.
+        if_static : bool, default=False
+            Exclude job ID, state, and failure count when true.
 
         Returns
         -------
-        task_dict : dict
-            the dictionary converted from the Task class instance
+        dict
+            Mapping from the deterministic job hash to job data.
         """
         job_content_dict = {}
         # for task in self.job_task_list:
@@ -1158,9 +1158,11 @@ class Job:
         return {job_hash: job_content_dict}
 
     def register_job_id(self, job_id: str | int) -> None:
+        """Store the identifier returned by the scheduler."""
         self.job_id = job_id
 
     def submit_job(self) -> None:
+        """Submit the job through its machine and update its local state."""
         assert self.machine is not None
         job_id = self.machine.do_submit(self)
         self.register_job_id(job_id)
@@ -1170,6 +1172,7 @@ class Job:
             self.job_state = JobStatus.unsubmitted
 
     def job_to_json(self) -> None:
+        """Write current job state to the execution root as JSON."""
         write_str = json.dumps(self.serialize(), indent=2, default=str)
         assert self.machine is not None
         self.machine.context.write_file(
@@ -1223,40 +1226,47 @@ class Job:
 
 
 class Resources:
-    """Resources is used to describe the machine resources we need to do calculations.
+    """Describe the resources and execution strategy for generated jobs.
 
     Parameters
     ----------
     number_node : int
-        The number of node need for each `job`.
+        Number of nodes requested for each generated job.
     cpu_per_node : int
-        cpu numbers of each node.
+        Number of CPUs requested on each node.
     gpu_per_node : int
-        gpu numbers of each node.
+        Number of GPUs requested on each node.
     queue_name : str
-        The queue name of batch job scheduler system.
+        Queue or partition name passed to the batch backend.
     group_size : int
-        The number of `tasks` in a `job`.
-    custom_flags : list of Str
-        The extra lines pass to job submitting script header
-    strategy : dict
-        strategies we use to generation job submitting scripts.
-        if_cuda_multi_devices : bool
-            If there are multiple nvidia GPUS on the node, and we want to assign the tasks to different GPUS.
-            If true, dpdispatcher will manually export environment variable CUDA_VISIBLE_DEVICES to different task.
-            Usually, this option will be used with Task.task_need_resources variable simultaneously.
-        ratio_unfinished : float
-            The ratio of `task` that can be unfinished.
-        customized_script_header_template_file : str
-            The customized template file to generate job submitting script header,
-            which overrides the default file.
-    para_deg : int
-        Decide how many tasks will be run in parallel.
-        Usually run with `strategy['if_cuda_multi_devices']`
-    source_list : list of Path
-        The env file to be sourced before the command execution.
-    wait_time : int
-        The waitting time in second after a single task submitted. Default: 0.
+        Maximum number of tasks grouped into one scheduler job. Zero groups all
+        tasks into one job.
+    custom_flags : list of str, optional
+        Extra scheduler directives inserted into the generated script header.
+    strategy : dict, optional
+        Script-generation strategy. Recognized keys include
+        ``if_cuda_multi_devices``, ``ratio_unfinished``, and
+        ``customized_script_header_template_file``.
+    para_deg : int, default=1
+        Number of task commands run concurrently inside one generated job.
+    module_unload_list : list of str, optional
+        Environment modules to unload before task execution.
+    module_purge : bool, default=False
+        Whether to purge loaded environment modules first.
+    module_list : list of str, optional
+        Environment modules to load before task execution.
+    source_list : list of str, optional
+        Shell files to source before task execution.
+    envs : dict, optional
+        Environment variables to export before task execution.
+    prepend_script : list of str, optional
+        Shell lines inserted before task commands.
+    append_script : list of str, optional
+        Shell lines inserted after all task commands finish.
+    wait_time : int, default=0
+        Delay in seconds after each job submission or resubmission.
+    **kwargs
+        Backend-specific resource options, stored in ``Resources.kwargs``.
     """
 
     def __init__(
@@ -1330,6 +1340,7 @@ class Resources:
         return json.dumps(self.serialize()) == json.dumps(other.serialize())  # type: ignore[attr-defined]
 
     def serialize(self) -> dict[str, Any]:  # noqa: ANN401
+        """Return the resource request as a JSON-compatible dictionary."""
         resources_dict = {}
         resources_dict["number_node"] = self.number_node
         resources_dict["cpu_per_node"] = self.cpu_per_node
@@ -1353,6 +1364,7 @@ class Resources:
 
     @classmethod
     def deserialize(cls, resources_dict: dict[str, Any]) -> "Resources":  # noqa: ANN401
+        """Reconstruct a resource request from a serialized dictionary."""
         resources = cls(
             number_node=resources_dict.get("number_node", 1),
             cpu_per_node=resources_dict.get("cpu_per_node", 1),
@@ -1379,6 +1391,7 @@ class Resources:
 
     @classmethod
     def load_from_json(cls, json_file: str) -> "Resources":
+        """Load and validate a resource request from a JSON file."""
         with open(json_file) as f:
             resources_dict = json.load(f)
         resources = cls.load_from_dict(resources_dict=resources_dict)
@@ -1386,6 +1399,7 @@ class Resources:
 
     @classmethod
     def load_from_yaml(cls, yaml_file: str) -> "Resources":
+        """Load and validate a resource request from a YAML file."""
         with open(yaml_file) as f:
             resources_dict = yaml.safe_load(f)
         resources = cls.load_from_dict(resources_dict=resources_dict)
@@ -1416,6 +1430,7 @@ class Resources:
 
     @staticmethod
     def arginfo(detail_kwargs: bool = True) -> Argument:
+        """Build the dargs schema for common and backend-specific resources."""
         doc_number_node = "Number of nodes requested for each scheduler job generated by DPDispatcher."
         doc_cpu_per_node = (
             "Number of CPUs requested on each node for each scheduler job."

--- a/dpdispatcher/utils/dpcloudserver/__init__.py
+++ b/dpdispatcher/utils/dpcloudserver/__init__.py
@@ -1,3 +1,5 @@
+"""Expose helpers for the legacy Bohrium cloud-service API."""
+
 from .client import Client
 
 __all__ = ["Client"]

--- a/dpdispatcher/utils/dpcloudserver/client.py
+++ b/dpdispatcher/utils/dpcloudserver/client.py
@@ -1,3 +1,5 @@
+"""Provide a legacy HTTP client for Bohrium job and storage operations."""
+
 import os
 import re
 import time
@@ -22,10 +24,12 @@ ENABLE_STACK = True if API_LOGGER_STACK_INFO else False
 
 
 class RequestInfoException(Exception):
-    pass
+    """Report a failed legacy Bohrium API request."""
 
 
 class Client:
+    """Call legacy Bohrium APIs for authentication, jobs, logs, and files."""
+
     def __init__(
         self,
         email: str | None = None,

--- a/dpdispatcher/utils/dpcloudserver/config.py
+++ b/dpdispatcher/utils/dpcloudserver/config.py
@@ -1,3 +1,5 @@
+"""Read legacy Bohrium API endpoints and object-storage settings."""
+
 import os
 
 HTTP_TIME_OUT = 30

--- a/dpdispatcher/utils/dpcloudserver/retcode.py
+++ b/dpdispatcher/utils/dpcloudserver/retcode.py
@@ -1,6 +1,11 @@
+"""Define return codes used by the legacy Bohrium API."""
+
+
 # 2开头的错误代码第二位代表错误等级
 # 0. 严重错误; 1. 普通错误; 2. 规则错误; 3. 一般信息; 4. 未知错误
 class RETCODE:
+    """Group string constants returned by the legacy Bohrium API."""
+
     OK = "0000"  # 正常
     DBERR = "2000"  # 数据库异常
     THIRDERR = "2001"  # 第三方异常

--- a/dpdispatcher/utils/dpcloudserver/zip_file.py
+++ b/dpdispatcher/utils/dpcloudserver/zip_file.py
@@ -1,3 +1,5 @@
+"""Create and extract ZIP archives for cloud file transfer."""
+
 import glob
 import os
 from collections.abc import Iterable
@@ -15,7 +17,7 @@ def zip_file_list(
     zip_filename: str,
     file_list: Iterable[str] | None = None,
 ) -> str:
-    """Archive files matched relative to ``root_path`` into ``zip_filename``."""
+    """Create a ZIP archive from paths and glob patterns below a root."""
     out_zip_file = os.path.join(root_path, zip_filename)
     # print('debug: file_list', file_list)
     patterns = file_list if file_list is not None else ()
@@ -86,6 +88,6 @@ def zip_file_list(
 
 
 def unzip_file(zip_file: str, out_dir: str = "./") -> None:
-    """Extract a cloud result zip after validating every archive member."""
+    """Extract a ZIP archive into a local directory."""
     with ZipFile(zip_file, "r") as obj:
         safe_extract_zip(obj, out_dir)

--- a/dpdispatcher/utils/hdfs_cli.py
+++ b/dpdispatcher/utils/hdfs_cli.py
@@ -1,5 +1,7 @@
 # /usr/bin/python
 
+"""Wrap the Hadoop CLI operations used by the HDFS context."""
+
 import os
 import shlex
 from collections.abc import Sequence
@@ -31,26 +33,11 @@ def _validate_operand(value: str, name: str) -> str:
 
 
 class HDFS:
-    """Provide basic HDFS filesystem operations through the Hadoop CLI.
-
-    Path and URI operands are passed literally without shell expansion.  Callers
-    that need local ``~`` expansion must resolve it before invoking these helpers.
-    """
+    """Fundamental class for HDFS basic manipulation."""
 
     @staticmethod
     def exists(uri: str) -> bool:
-        """Return whether an HDFS URI exists.
-
-        Parameters
-        ----------
-        uri : str
-            HDFS URI to inspect.
-
-        Raises
-        ------
-        RuntimeError
-            If Hadoop returns an unexpected status or cannot be executed.
-        """
+        """Return whether an HDFS URI exists."""
         uri = _validate_operand(uri, "uri")
         command = ["hadoop", "fs", "-test", "-e", uri]
         command_text = _command_text(command)
@@ -109,7 +96,7 @@ class HDFS:
 
     @staticmethod
     def copy_from_local(local_path: str, to_uri: str) -> tuple[bool, bytes]:
-        """Copy one readable local path to HDFS, replacing an existing file."""
+        """Copy a readable local path to an HDFS URI."""
         local_path = _validate_operand(local_path, "local_path")
         to_uri = _validate_operand(to_uri, "to_uri")
         if not os.path.exists(local_path) or not os.access(local_path, os.R_OK):
@@ -133,7 +120,7 @@ class HDFS:
     def copy_to_local(
         from_uri: str | list[str] | tuple[str, ...], local_path: str
     ) -> bool:
-        """Copy one or more HDFS URIs to a local path."""
+        """Copy one or more HDFS paths into a local directory."""
         if isinstance(from_uri, str):
             remote_arguments = [_validate_operand(from_uri, "from_uri")]
         elif isinstance(from_uri, (list, tuple)):
@@ -167,7 +154,7 @@ class HDFS:
 
     @staticmethod
     def read_hdfs_file(uri: str) -> bytes:
-        """Read an HDFS file through ``hadoop fs -text``."""
+        """Return the decoded output of ``hadoop fs -text`` for an HDFS URI."""
         uri = _validate_operand(uri, "uri")
         command = ["hadoop", "fs", "-text", uri]
         command_text = _command_text(command)
@@ -186,7 +173,7 @@ class HDFS:
 
     @staticmethod
     def move(from_uri: str, to_uri: str) -> bool:
-        """Move an HDFS URI to another HDFS URI."""
+        """Move an HDFS path to a new URI."""
         from_uri = _validate_operand(from_uri, "from_uri")
         to_uri = _validate_operand(to_uri, "to_uri")
         command = ["hadoop", "fs", "-mv", from_uri, to_uri]

--- a/dpdispatcher/utils/job_status.py
+++ b/dpdispatcher/utils/job_status.py
@@ -1,7 +1,11 @@
+"""Define scheduler-independent states for jobs and tasks."""
+
 from enum import IntEnum
 
 
 class JobStatus(IntEnum):
+    """Represent normalized lifecycle states returned by machine backends."""
+
     unsubmitted = 1
     waiting = 2
     running = 3

--- a/dpdispatcher/utils/record.py
+++ b/dpdispatcher/utils/record.py
@@ -1,3 +1,5 @@
+"""Persist recoverable submission state in the user's data directory."""
+
 from __future__ import annotations
 
 import json
@@ -53,8 +55,6 @@ class Record:
         ----------
         hash : str
             Hash of submission data.
-        not_exist_ok : bool
-            If True, return the expected path even when the record does not exist.
 
         Returns
         -------

--- a/dpdispatcher/utils/utils.py
+++ b/dpdispatcher/utils/utils.py
@@ -1,3 +1,5 @@
+"""Provide hashing, authentication, retry, transfer, and script helpers."""
+
 import base64
 import hashlib
 import hmac
@@ -40,6 +42,7 @@ def get_sha256(filename: str) -> str:
 
 
 def hotp(key: str, period: int, token_length: int = 6, digest: str = "sha1") -> str:
+    """Generate an HMAC-based one-time password for a counter value."""
     key_ = base64.b32decode(key.upper() + "=" * ((8 - len(key)) % 8))
     period_ = struct.pack(">Q", period)
     mac = hmac.new(key_, period_, digest).digest()
@@ -79,11 +82,7 @@ def generate_totp(secret: str, period: int = 30, token_length: int = 6) -> str:
 def run_cmd_with_all_output(
     cmd: str | Sequence[str], shell: bool = True
 ) -> tuple[int, bytes, bytes]:
-    """Run a command and return its status, standard output, and standard error.
-
-    When shell execution is disabled, callers may pass an argument sequence so
-    values remain literal operands and are never reinterpreted by a shell.
-    """
+    """Run a command and return its exit code, standard output, and error."""
     with subprocess.Popen(
         cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     ) as proc:
@@ -225,6 +224,7 @@ def retry(
 def customized_script_header_template(
     filename: os.PathLike, resources: "Resources"
 ) -> str:
+    """Render a user-provided scheduler header with resource values."""
     with open(filename) as f:
         template = f.read()
     return template.format(**resources.serialize())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,16 +101,21 @@ ignore = [
     "D203", # 1 blank line required before class docstring
     "D107", # missing docstring in __init__
     "D213", # multi-line docstring summary should start at the second line
-    "D100", # TODO: missing docstring in public module
-    "D101", # TODO: missing docstring in public class
-    "D102", # TODO: missing docstring in public method
-    "D103", # TODO: missing docstring in public function
-    "D104", # TODO: missing docstring in public package
     "D105", # TODO: missing docstring in magic method
-    "D205", # 1 blank line required between summary line and description
-    "D401", # TODO: first line should be in imperative mood
-    "D404", # TODO: first word of the docstring should not be This
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Backend overrides inherit the contracts documented by Machine and BaseContext.
+# Keep the exception narrow so new public modules, classes, and functions still
+# require documentation while legacy backend methods are migrated incrementally.
+"dpdispatcher/contexts/*.py" = ["D102"]
+"dpdispatcher/machines/*.py" = ["D102"]
+"dpdispatcher/utils/dpcloudserver/client.py" = ["D102"]
+# Tests, runnable examples, and build configuration are not public Python APIs.
+"tests/*.py" = ["D"]
+"examples/*.py" = ["D"]
+"scripts/*.py" = ["D"]
+"doc/conf.py" = ["D"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
## Summary

- Expand public API docstrings for submissions, tasks, jobs, resources, machines, contexts, utilities, and scheduler backends.
- Add a Python API guide covering local execution, path and staging semantics, grouping, configuration loading, lifecycle options, and extension points.
- Improve the getting-started, backend, context, installation, and contributor documentation.
- Enable Ruff pydocstyle rules and document the narrow exclusions for legacy backend/test modules.
- Improve Sphinx API generation and build behavior.

## Validation

- `uvx pre-commit run --all-files`
- `uvx ruff check .`
- `uvx ruff format --check .`
- Full unittest suite: 303 passed, 47 skipped; coverage report generated.
- `dpdisp --help`
- `dpdisp run examples/dpdisp_run.py`
- Documented local Python API example executed successfully.
- Online Sphinx HTML build succeeded with 18 existing cross-reference/autosummary warnings.
- Offline Sphinx HTML build succeeded with intersphinx disabled; remaining warnings are expected unresolved cross-references without inventories.
- Pyright reports no new diagnostics compared with `origin/master`; existing repository type-checking diagnostics remain.

Coding agent: Codex
Codex version: codex-cli 0.151.0
Model: gpt-5.6-sol
Reasoning effort: xhigh
