### PR TITLE
fix: quote REMOTE_ROOT in generated shell scripts

### DIFF
--- a/dpdispatcher/machine.py
+++ b/dpdispatcher/machine.py
@@ -30,7 +30,7 @@ script_template = """\
 
 script_env_template = """
 REMOTE_ROOT=$(readlink -f {remote_root})
-echo 0 > $REMOTE_ROOT/{flag_if_job_task_fail}
+echo 0 > "$REMOTE_ROOT/{flag_if_job_task_fail}"
 test $? -ne 0 && exit 1
 
 {module_unload_part}
@@ -41,17 +41,17 @@ test $? -ne 0 && exit 1
 """
 
 script_command_template = """
-cd $REMOTE_ROOT
+cd "$REMOTE_ROOT"
 cd {task_work_path}
 test $? -ne 0 && exit 1
 if [ ! -f {task_tag_finished} ] ;then
   {command_env} ( {command} ) {log_err_part}
-  if test $? -eq 0; then touch {task_tag_finished}; else echo 1 > $REMOTE_ROOT/{flag_if_job_task_fail};{failure_diagnostic_part}fi
+  if test $? -eq 0; then touch {task_tag_finished}; else echo 1 > "$REMOTE_ROOT/{flag_if_job_task_fail}";{failure_diagnostic_part}fi
 fi &
 """
 
 script_end_template = """
-cd $REMOTE_ROOT
+cd "$REMOTE_ROOT"
 test $? -ne 0 && exit 1
 
 wait
@@ -427,7 +427,7 @@ class Machine(metaclass=ABCMeta):
 
     def gen_script_run_command(self, job: Job) -> str:
         """Return the command that sources the generated per-task script."""
-        return f"source $REMOTE_ROOT/{job.script_file_name}.run"
+        return f'source "$REMOTE_ROOT/{job.script_file_name}.run"'
 
     def gen_script(self, job: Job) -> str:
         """Generate the complete scheduler submission script for a job."""
@@ -575,8 +575,8 @@ class Machine(metaclass=ABCMeta):
         task_work_path = shlex.quote(pathlib.PurePath(task.task_work_path).as_posix())
         return (
             "tail -v -c 1000 "
-            f"$REMOTE_ROOT/{task_work_path}/{shlex.quote(task.errlog)} "
-            f"> $REMOTE_ROOT/{shlex.quote(last_err_file)};"
+            f'"$REMOTE_ROOT"/{task_work_path}/{shlex.quote(task.errlog)} '
+            f'> "$REMOTE_ROOT"/{shlex.quote(last_err_file)};'
         )
 
     def gen_script_end(self, job: Job) -> str:

--- a/dpdispatcher/machines/distributed_shell.py
+++ b/dpdispatcher/machines/distributed_shell.py
@@ -41,7 +41,7 @@ for TGZ in `ls *.tgz`; do tar xvf $TGZ; done
 
 """
 script_end_template = """
-cd $REMOTE_ROOT
+cd "$REMOTE_ROOT"
 test $? -ne 0 && exit 1
 
 wait

--- a/dpdispatcher/machines/distributed_shell.py
+++ b/dpdispatcher/machines/distributed_shell.py
@@ -72,7 +72,7 @@ class DistributedShell(Machine):
             module_unload_part += f"module unload {ii}\n"
 
         module_load_part = ""
-        module_list = job.resources.module_list
+        module_list = job.resources.module_load_list
         for ii in module_list:
             module_load_part += f"module load {ii}\n"
 
@@ -96,7 +96,7 @@ class DistributedShell(Machine):
             source_files_part=source_files_part,
             export_envs_part=export_envs_part,
             prepend_script_part=prepend_script_part,
-            remote_root=self.context.remote_root,
+            remote_root=shlex.quote(self.context.remote_root),
             submission_hash=self.context.submission.submission_hash,
         )
         return script_env
@@ -116,7 +116,7 @@ class DistributedShell(Machine):
             flag_if_job_task_fail=flag_if_job_task_fail,
             all_task_dirs=all_task_dirs,
             append_script_part=append_script_part,
-            remote_root=self.context.remote_root,
+            remote_root=shlex.quote(self.context.remote_root),
             submission_hash=self.context.submission.submission_hash,
             job_hash=job.job_hash,
         )
@@ -194,6 +194,7 @@ class DistributedShell(Machine):
         job_id = int(stdout.decode("utf-8").strip())
 
         self.context.write_file(job_id_name, str(job_id))
+
         return job_id
 
     def check_status(self, job: "Job") -> JobStatus:

--- a/dpdispatcher/machines/distributed_shell.py
+++ b/dpdispatcher/machines/distributed_shell.py
@@ -72,7 +72,7 @@ class DistributedShell(Machine):
             module_unload_part += f"module unload {ii}\n"
 
         module_load_part = ""
-        module_list = job.resources.module_load_list
+        module_list = job.resources.module_list
         for ii in module_list:
             module_load_part += f"module load {ii}\n"
 
@@ -194,7 +194,6 @@ class DistributedShell(Machine):
         job_id = int(stdout.decode("utf-8").strip())
 
         self.context.write_file(job_id_name, str(job_id))
-
         return job_id
 
     def check_status(self, job: "Job") -> JobStatus:

--- a/dpdispatcher/run.py
+++ b/dpdispatcher/run.py
@@ -132,7 +132,7 @@ def create_submission(
     tasks = []
     for task in metadata["task_list"]:
         task = task.copy()
-        task["command"] += f" $REMOTE_ROOT/script_{script_hash}.py"
+        task["command"] += f' "$REMOTE_ROOT/script_{script_hash}.py"'
         local_work_base = os.path.join(
             metadata["machine"]["local_root"],
             metadata["work_base"],

--- a/tests/test_none_errlog_script_generation.py
+++ b/tests/test_none_errlog_script_generation.py
@@ -33,7 +33,9 @@ class TestNoneErrlogScriptGeneration(unittest.TestCase):
         self.assertNotIn("1>>", script)
         self.assertNotIn("2>>", script)
         self.assertNotIn("tail -v", script)
-        self.assertIn("echo 1 > $REMOTE_ROOT/job-hash_flag_if_job_task_fail", script)
+        self.assertIn(
+            'echo 1 > "$REMOTE_ROOT/job-hash_flag_if_job_task_fail"', script
+        )
 
     def test_generic_machine_keeps_tail_for_configured_errlog(self) -> None:
         machine = self._make_machine("Shell")
@@ -43,10 +45,10 @@ class TestNoneErrlogScriptGeneration(unittest.TestCase):
 
         self.assertIn("2>>'error log'", script)
         self.assertIn(
-            "tail -v -c 1000 $REMOTE_ROOT/'task dir'/'error log'",
+            'tail -v -c 1000 "$REMOTE_ROOT"/\'task dir\'/\'error log\'',
             script,
         )
-        self.assertIn("> $REMOTE_ROOT/job-hash_last_err_file", script)
+        self.assertIn('> "$REMOTE_ROOT"/job-hash_last_err_file', script)
 
     def test_slurm_job_array_handles_mixed_errlogs(self) -> None:
         machine = self._make_machine("SlurmJobArray")
@@ -59,7 +61,7 @@ class TestNoneErrlogScriptGeneration(unittest.TestCase):
 
         self.assertEqual(script.count("tail -v -c 1000"), 1)
         self.assertNotIn("task-a/''", script)
-        self.assertIn("$REMOTE_ROOT/task-b/err", script)
+        self.assertIn('"$REMOTE_ROOT"/task-b/err', script)
 
     def test_terminated_log_files_filter_optional_names(self) -> None:
         cases = (

--- a/tests/test_none_errlog_script_generation.py
+++ b/tests/test_none_errlog_script_generation.py
@@ -33,9 +33,7 @@ class TestNoneErrlogScriptGeneration(unittest.TestCase):
         self.assertNotIn("1>>", script)
         self.assertNotIn("2>>", script)
         self.assertNotIn("tail -v", script)
-        self.assertIn(
-            'echo 1 > "$REMOTE_ROOT/job-hash_flag_if_job_task_fail"', script
-        )
+        self.assertIn('echo 1 > "$REMOTE_ROOT/job-hash_flag_if_job_task_fail"', script)
 
     def test_generic_machine_keeps_tail_for_configured_errlog(self) -> None:
         machine = self._make_machine("Shell")
@@ -45,7 +43,7 @@ class TestNoneErrlogScriptGeneration(unittest.TestCase):
 
         self.assertIn("2>>'error log'", script)
         self.assertIn(
-            'tail -v -c 1000 "$REMOTE_ROOT"/\'task dir\'/\'error log\'',
+            "tail -v -c 1000 \"$REMOTE_ROOT\"/'task dir'/'error log'",
             script,
         )
         self.assertIn('> "$REMOTE_ROOT"/job-hash_last_err_file', script)

--- a/tests/test_remote_root_quoting.py
+++ b/tests/test_remote_root_quoting.py
@@ -10,7 +10,9 @@ from dpdispatcher.machine import Machine
 
 class TestRemoteRootQuoting(unittest.TestCase):
     def test_shell_generated_script_runs_when_remote_root_contains_spaces(self) -> None:
-        with tempfile.TemporaryDirectory(prefix="dpdispatcher remote root ") as remote_root:
+        with tempfile.TemporaryDirectory(
+            prefix="dpdispatcher remote root "
+        ) as remote_root:
             remote_path = Path(remote_root)
             task_dir = remote_path / "task dir"
             task_dir.mkdir()

--- a/tests/test_remote_root_quoting.py
+++ b/tests/test_remote_root_quoting.py
@@ -1,0 +1,61 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from dpdispatcher import Resources, Task
+from dpdispatcher.machine import Machine
+
+
+class TestRemoteRootQuoting(unittest.TestCase):
+    def test_shell_generated_script_runs_when_remote_root_contains_spaces(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dpdispatcher remote root ") as remote_root:
+            remote_path = Path(remote_root)
+            task_dir = remote_path / "task dir"
+            task_dir.mkdir()
+
+            task = Task(
+                "printf 'ok' > result.txt",
+                "task dir",
+                outlog=None,
+                errlog="error log",
+            )
+            resources = Resources(1, 1, 0, "", 1)
+            job = SimpleNamespace(
+                resources=resources,
+                job_task_list=[task],
+                job_hash="job-hash",
+                script_file_name="job.sub",
+                fail_count=0,
+            )
+            machine = Machine(
+                batch_type="Shell",
+                context_type="LazyLocalContext",
+                local_root=".",
+            )
+            machine.context.remote_root = remote_root
+
+            (remote_path / "job.sub.run").write_text(
+                machine.gen_script_command(job), encoding="utf-8"
+            )
+            completed = subprocess.run(
+                ["bash"],
+                input=machine.gen_script(job),
+                cwd=remote_root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual((task_dir / "result.txt").read_text(), "ok")
+            self.assertEqual(
+                (remote_path / "job-hash_flag_if_job_task_fail").read_text().strip(),
+                "0",
+            )
+            self.assertTrue((remote_path / "job-hash_job_tag_finished").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -80,7 +80,7 @@ class TestRun(unittest.TestCase):
             )
             self.assertTrue(
                 all(
-                    task.command.endswith(" $REMOTE_ROOT/script_abc.py")
+                    task.command.endswith(' "$REMOTE_ROOT/script_abc.py"')
                     for task in submission.belonging_tasks
                 )
             )


### PR DESCRIPTION
## Summary

Fixes #667.

Generated job scripts expanded `REMOTE_ROOT` without shell quoting in several places. A remote root containing whitespace was therefore split into multiple shell words during `cd`, failure-marker writes, sourcing the generated `.run` script, diagnostic capture, and the PEP 723 script invocation.

## Changes

- quote every generic generated-script use of `REMOTE_ROOT`
- quote the DistributedShell final `cd`
- quote the PEP 723 script path appended to task commands
- keep task/log path components independently shell-quoted in failure diagnostics
- add an execution regression test that runs a generated Shell script from a remote root containing spaces
- update existing script-generation expectations

## Testing

CI requested via this draft PR. The new regression test executes the generated bash script and verifies the task result, failure marker, and completion tag under a spaced remote-root path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of remote paths containing spaces or shell-special characters.
  * Fixed generated commands, directory changes, logging, and diagnostics to safely quote remote paths.

* **Tests**
  * Added coverage confirming generated scripts run successfully with paths containing spaces.
  * Updated command-generation expectations to reflect safer path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->